### PR TITLE
Set readiness probe correctly

### DIFF
--- a/client/src/main/scala/skuber/Container.scala
+++ b/client/src/main/scala/skuber/Container.scala
@@ -78,7 +78,7 @@ case class Container(
     withLivenessProbe(probe)
   }
   def withReadinessProbe(probe:Probe) =
-    this.copy(livenessProbe=Some(probe))
+    this.copy(readinessProbe=Some(probe))
   def withHttpReadinessProbe(
     path: String,
     port: NameablePort = 80,


### PR DESCRIPTION
Rather than setting the liveness probe to the provided readiness probe,
correctly set the readiness probe to the given input.