### PR TITLE
Avoid DNS host checking with extended trust manager

### DIFF
--- a/client/src/main/scala/skuber/api/security/TLS.scala
+++ b/client/src/main/scala/skuber/api/security/TLS.scala
@@ -1,10 +1,11 @@
 package skuber.api.security
 
-import javax.net.ssl.{KeyManager, KeyManagerFactory, TrustManager, TrustManagerFactory, X509TrustManager, X509ExtendedTrustManager, SSLContext}
+import java.net.Socket
+import javax.net.ssl._
 import java.security.cert.X509Certificate
 import java.security.SecureRandom
 
-import skuber.api.client.{Context,PathOrData}
+import skuber.api.client.{Context, PathOrData}
 
 /**
  * @author David O'Riordan
@@ -13,11 +14,15 @@ object TLS {
   
   // This trust manager supports the InsecureSkipTLSVerify flag in kubeconfig files -
   // it always trusts the server i.e. skips verifying the server cert for a TLS connection
-  object InsecureSkipTLSVerifyTrustManager extends X509TrustManager
+  object InsecureSkipTLSVerifyTrustManager extends X509ExtendedTrustManager
   {
     def getAcceptedIssuers() = Array[X509Certificate]()
     def checkClientTrusted(certs: Array[X509Certificate], authType: String) : Unit = {}
     def checkServerTrusted(certs: Array[X509Certificate], authType: String) : Unit = {}
+    def checkClientTrusted(certs: Array[X509Certificate], s: String, socket: Socket): Unit = {}
+    def checkClientTrusted(certs: Array[X509Certificate], s: String, sslEngine: SSLEngine): Unit = {}
+    def checkServerTrusted(certs: Array[X509Certificate], s: String, socket: Socket): Unit = {}
+    def checkServerTrusted(certs: Array[X509Certificate], s: String, sslEngine: SSLEngine): Unit = {}
   }
    
   val skipTLSTrustManagers = Array[TrustManager](InsecureSkipTLSVerifyTrustManager)


### PR DESCRIPTION
Avoid DNS host checking with extended trust manager

Sun's SSL implementation now checks if the trust manager on the SSL
context is a ExtendedTrustManager, and if not it wraps it an an
AbstractTrustManager that does extra checking to ensure that the DNS
host on the request matches the specified hosts on the certificate.

This changes skuber insecure trust manager to be an extended trust
manager to avoid that extra DNS check. Otherwise, in test circumstances
where a certificate does not list the correct DNS that is used for the
host then we are unable to connect to the kubernetes cluster.