### PR TITLE
Treat namespaces consistently with K8s API

### DIFF
--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -245,7 +245,7 @@ package object client {
    implicit val serviceKind = ObjKind[Service]("services", "Service")
    implicit val replCtrllrKind = ObjKind[ReplicationController]("replicationcontrollers", "ReplicationController")
    implicit val endpointsKind = ObjKind[Endpoints]("endpoints", "Endpoints")
-   implicit val namespaceKind = ObjKind[Namespace]("namespace", "Namespace")
+   implicit val namespaceKind = new ObjKind[Namespace]("namespaces", "Namespace") { override def isNamespaced = false }
    implicit val persistentVolumeKind = ObjKind[PersistentVolume]("persistentvolumes", "PersistentVolume")
    implicit val persistentVolumeClaimsKind = ObjKind[PersistentVolumeClaim]("persistentvolumeclaims", "PersistentVolumeClaim")
    implicit val serviceAccountKind = ObjKind[ServiceAccount]("serviceaccounts","ServiceAccount")


### PR DESCRIPTION
Namespaces are not namespace specific, so set `isNamespaced = false`, and for consistency with other models, use the plural in the `ObjKind` definition.