### PR TITLE
Add DaemonSet and ConfigMap representations

### DIFF
--- a/client/src/main/scala/skuber/ConfigMap.scala
+++ b/client/src/main/scala/skuber/ConfigMap.scala
@@ -1,0 +1,11 @@
+package skuber
+
+/**
+  * @author Cory Klein
+  */
+case class ConfigMap(val kind: String ="ConfigMap",
+                     override val apiVersion: String = v1,
+                     val metadata: ObjectMeta,
+                     data: Map[String, String] = Map())
+  extends ObjectResource
+

--- a/client/src/main/scala/skuber/ext/DaemonSet.scala
+++ b/client/src/main/scala/skuber/ext/DaemonSet.scala
@@ -1,0 +1,23 @@
+package skuber.ext
+
+import skuber.{LabelSelector, ObjectMeta, ObjectResource, Pod}
+
+/**
+  * @author Cory Klein
+  */
+case class DaemonSet(val kind: String ="Secret",
+                     override val apiVersion: String = extensionsAPIVersion,
+                     val metadata: ObjectMeta,
+                     spec:  Option[DaemonSet.Spec] = None,
+                     status:  Option[DaemonSet.Status] = None)
+  extends ObjectResource {
+}
+
+object DaemonSet {
+  case class Spec(selector: Option[LabelSelector] = None,
+                  template: Option[Pod.Template.Spec] = None)
+
+  case class Status(currentNumberScheduled: Int = 0,
+                    numberMisscheduled: Int = 0,
+                    desiredNumberScheduled: Int = 0)
+}

--- a/client/src/main/scala/skuber/json/ext/format/package.scala
+++ b/client/src/main/scala/skuber/json/ext/format/package.scala
@@ -41,7 +41,15 @@ package object format {
   implicit val hpasSpecFmt: Format[HorizontalPodAutoscaler.Spec] = Json.format[HorizontalPodAutoscaler.Spec]
   implicit val hpasStatusFmt: Format[HorizontalPodAutoscaler.Status] = Json.format[HorizontalPodAutoscaler.Status]
   implicit val hpasFmt: Format[HorizontalPodAutoscaler] =  Json.format[HorizontalPodAutoscaler]
-   
+
+  // DaemonSet formatters
+  implicit val daemonsetStatusFmt: Format[DaemonSet.Status] = Json.format[DaemonSet.Status]
+  implicit val daemonsetSpecFormat: Format[DaemonSet.Spec] = (
+    (JsPath \ "selector").formatNullableLabelSelector and
+      (JsPath \ "template").formatNullable[Pod.Template.Spec]
+    )(DaemonSet.Spec.apply, unlift(DaemonSet.Spec.unapply))
+  implicit val daemonsetFmt: Format[DaemonSet] = Json.format[DaemonSet]
+
   // Deployment formatters
   implicit val depStatusFmt: Format[Deployment.Status] = (
     (JsPath \ "replicas").formatMaybeEmptyInt() and

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -614,7 +614,9 @@ package object format {
     (JsPath \ "spec").formatNullable[PersistentVolumeClaim.Spec] and
     (JsPath \ "status").formatNullable[PersistentVolumeClaim.Status]
   )(PersistentVolumeClaim.apply _, unlift(PersistentVolumeClaim.unapply))
-  
+
+  implicit val configMapFmt: Format[ConfigMap] = Json.format[ConfigMap]
+
   implicit val svcAccountFmt: Format[ServiceAccount] = (
     objFormat and
     (JsPath \ "secrets").formatMaybeEmptyList[ObjectReference] and


### PR DESCRIPTION
ConfigMap is part of the v1 api version and DaemonSet is part of the
beta extensions.

@doriordan Attempted to follow the established conventions from other preexisting Kubernetes models when writing these. Let me know if you'd like me to make any changes or modifications.