### PR TITLE
Fix de/serialization of Secret's data member

### DIFF
--- a/client/src/test/scala/skuber/json/SecretSpec.scala
+++ b/client/src/test/scala/skuber/json/SecretSpec.scala
@@ -1,0 +1,26 @@
+package skuber.json
+
+import org.specs2.mutable.Specification
+import skuber.{ObjectMeta, Secret} // for unit-style testing
+import format._
+
+import play.api.libs.json._
+
+/**
+  * @author Cory Klein
+  */
+class SecretSpec extends Specification {
+
+  "A Secret containing a byte array can symmetrically be written to json and the same value read back in" >> {
+    val dataBytes = "hello".getBytes
+    val secret = Secret(metadata = ObjectMeta("mySecret"), data = Map("key" -> dataBytes))
+    val resultBytes = Json.fromJson[Secret](Json.toJson(secret)).get.data("key")
+    dataBytes mustEqual resultBytes
+  }
+  "this can be done with an empty data map" >> {
+    val mySecret = Secret(metadata = ObjectMeta("mySecret"))
+    val json = Json.toJson(mySecret)
+    val readSecret = Json.fromJson[Secret](Json.toJson(mySecret)).get
+    mySecret mustEqual readSecret
+  }
+}


### PR DESCRIPTION
A Secret has a member:

  data: Map[String, Array[Byte]]

Skuber threw an exception whenever a Secret was serialized or
deserialized when this data member was present because the usage of
formatMaybeEmptyMap did not allow the injection of:

  implicit base64Format: Format[Array[Byte]]

Thus, the byte array was not being serialized and deserialized via the
Base64.decodeBase and Base64.encodeBase64String methods, and whatever it
fell back to resulted in a JsValue being created instead of a JsObject.

After great, albeit failed, effort to get formatMaybeEmptyMap to correctly
use base64Format, I instead created formatMaybeEmptyByteArrayMap which
resolved the problem. I suspect that type erasure may preclude a more
elegant solution, but would love to know if one is possible.

I added unit tests to exercise the problem and solution. Without the
corresponding changes to the json package, the first unit test will
fail.