### PR TITLE
Secret type field addition

### DIFF
--- a/client/src/main/scala/skuber/Secret.scala
+++ b/client/src/main/scala/skuber/Secret.scala
@@ -10,7 +10,8 @@ case class Secret(
     val kind: String ="Secret",
     override val apiVersion: String = v1,
     val metadata: ObjectMeta,
-    data: Map[String, Array[Byte]] = Map())
+    data: Map[String, Array[Byte]] = Map(),
+    val `type`: String = "")
   extends ObjectResource  {
   
     def add(key: String, is: InputStream) : Unit = {

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -640,7 +640,8 @@ package object format {
   import skuber.Secret
   implicit val secretFmt: Format[Secret] = (
     objFormat and
-    (JsPath \ "data").formatMaybeEmptyByteArrayMap
+    (JsPath \ "data").formatMaybeEmptyByteArrayMap and
+    (JsPath \ "type").formatMaybeEmptyString()
   )(Secret.apply _, unlift(Secret.unapply))
   
   implicit val limitRangeItemTypeFmt: Format[LimitRange.ItemType.Type] = enumFormat(LimitRange.ItemType) 

--- a/client/src/test/scala/skuber/json/SecretSpec.scala
+++ b/client/src/test/scala/skuber/json/SecretSpec.scala
@@ -23,4 +23,9 @@ class SecretSpec extends Specification {
     val readSecret = Json.fromJson[Secret](Json.toJson(mySecret)).get
     mySecret mustEqual readSecret
   }
+  "this can be done with the type member defined" >> {
+    val mySecret = Secret(metadata = ObjectMeta("mySecret"), `type` = "myType")
+    val readSecret = Json.fromJson[Secret](Json.toJson(mySecret)).get
+    mySecret mustEqual readSecret
+  }
 }

--- a/client/src/test/scala/skuber/json/SecretSpec.scala
+++ b/client/src/test/scala/skuber/json/SecretSpec.scala
@@ -1,0 +1,26 @@
+package skuber.json
+
+import org.specs2.mutable.Specification
+import skuber.{ObjectMeta, Secret} // for unit-style testing
+import format._
+
+import play.api.libs.json._
+
+/**
+  * @author Cory Klein
+  */
+class SecretSpec extends Specification {
+
+  "A Secret containing a byte array can symmetrically be written to json and the same value read back in" >> {
+    val dataBytes = "hello".getBytes
+    val secret = Secret(metadata = ObjectMeta("mySecret"), data = Map("key" -> dataBytes))
+    val resultBytes = Json.fromJson[Secret](Json.toJson(secret)).get.data("key")
+    dataBytes mustEqual resultBytes
+  }
+  "this can be done with an empty data map" >> {
+    val mySecret = Secret(metadata = ObjectMeta("mySecret"))
+    val json = Json.toJson(mySecret)
+    val readSecret = Json.fromJson[Secret](Json.toJson(mySecret)).get
+    mySecret mustEqual readSecret
+  }
+}


### PR DESCRIPTION
This PR is an addition above [this one](https://github.com/doriordan/skuber/pull/10). Not sure if this is the most idiomatic way to do this in git or not, as this PR *contains* [PR-10](https://github.com/doriordan/skuber/pull/10) as well.

The commit for *this* PR is [Add "type" field to Secret](https://github.com/doriordan/skuber/commit/fa99ae265edd8219c12e97887b8ed1a853200aab)

I submitted this PR separate from PR-10 because I was uncertain if there was previous reasoning against including the `type` member on Kubernetes objects. It is fairly common, yet seems to be absent in Skuber.

For our purposes, we have Kubernetes resources that we need to create that require this property be defined with a specific value.