### PR TITLE
Fix 'valueForm' typo for secretKeyRef

### DIFF
--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -286,7 +286,7 @@ package object client {
     code: Option[Int] = None  // HTTP status code
   ) 
   
-  class K8SException(val status: Status) extends RuntimeException // we throw this when we receive a non-OK response
+  class K8SException(val status: Status) extends RuntimeException (status.message.getOrElse(status.toString)) // we throw this when we receive a non-OK response
    
   def toKubernetesResponse[T](response: WSResponse)(implicit reader: Reads[T]) : T = {
     checkResponseStatus(response)

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -182,7 +182,7 @@ package object format {
     (JsPath \ "value").read[String].map(value => EnvVar.StringValue(value)) |
     (JsPath \ "valueFrom" \ "fieldRef").read[EnvVar.FieldRef].map(x => x: EnvVar.Value) |
     (JsPath \ "valueFrom" \ "configMapKeyRef").read[EnvVar.ConfigMapKeyRef].map(x => x: EnvVar.Value) |
-    (JsPath \ "valueForm" \ "secretKeyRef").read[EnvVar.SecretKeyRef].map(x => x: EnvVar.Value)
+    (JsPath \ "valueFrom" \ "secretKeyRef").read[EnvVar.SecretKeyRef].map(x => x: EnvVar.Value)
   )
   
    implicit val envVarWrites : Writes[EnvVar] = (


### PR DESCRIPTION
There is a typo when using `secretKeyRef` breaking the ability to reference secrets via environment variables (http://kubernetes.io/docs/user-guide/secrets/#using-secrets-as-environment-variables)