### PR TITLE
Allow Spec to treat finalizers as optional, matches the spec

### DIFF
--- a/client/src/main/scala/skuber/Namespace.scala
+++ b/client/src/main/scala/skuber/Namespace.scala
@@ -21,13 +21,13 @@ case class Namespace(
       ReplicationController(metadata=meta(name), spec=Some(spec))
     def service(name: String) = Service(metadata=meta(name))
     def service(name:String, spec: Service.Spec) = Service(metadata=meta(name), spec=Some(spec))
-    def withFinalizers(f: List[String]) = { this.copy(spec = Some(Namespace.Spec(f))) } 
+    def withFinalizers(f: List[String]) = { this.copy(spec = Some(Namespace.Spec(Option(f)))) }
     def withStatusOfPhase(p: String) =  { this.copy(status = Some(Namespace.Status(p))) } 
     def withResourceVersion(version: String) = this.copy(metadata = metadata.copy(resourceVersion=version))
   }
 
 object Namespace {
-  case class Spec(finalizers: List[String])
+  case class Spec(finalizers: Option[List[String]])
   case class Status(phase: String)
  
   lazy val default = Namespace.forName("default")

--- a/client/src/test/scala/skuber/json/NamespaceFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/NamespaceFormatSpec.scala
@@ -42,6 +42,15 @@ class NamespaceFormatSpec extends Specification {
       val readNs = Json.fromJson[Namespace](Json.toJson(myOtherNs)).get
       readNs mustEqual myOtherNs
     }
+
+    "namespace spec allows finalizers to be optional" >> {
+      val readSpec = Json.fromJson[Namespace.Spec](Json.parse("{}")).get
+      readSpec.finalizers.isEmpty mustEqual true
+
+      val readSpec2 = Json.fromJson[Namespace.Spec](Json.parse("""{ "finalizers": ["kubernetes"]}""")).get
+      readSpec2.finalizers.get.head mustEqual "kubernetes"
+    }
+
     "we can read a namespace from a direct JSON string" >> {
       val nsJson = Json.parse("""
         {


### PR DESCRIPTION
This occurs sometimes while terminating a Namespace

Please note the api marks finalizers as 'not required': http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_namespacespec