### PR TITLE
add generation to metadata

### DIFF
--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -120,7 +120,8 @@ package object format {
     (JsPath \ "creationTimestamp").formatNullable[Timestamp] and
     (JsPath \ "deletionTimestamp").formatNullable[Timestamp] and
     (JsPath \ "labels").formatMaybeEmptyMap[String] and
-    (JsPath \ "annotations").formatMaybeEmptyMap[String]
+    (JsPath \ "annotations").formatMaybeEmptyMap[String] and
+    (JsPath \ "generation").formatMaybeEmptyInt()
   )(ObjectMeta.apply _, unlift(ObjectMeta.unapply))
     
   implicit val listMetaFormat: Format[ListMeta] = (

--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -39,7 +39,8 @@ package object skuber {
     creationTimestamp: Option[Timestamp] = None,
     deletionTimestamp: Option[Timestamp] = None,
     labels: Map[String, String] = Map(),
-    annotations: Map[String, String] = Map())
+    annotations: Map[String, String] = Map(),
+    generation: Int = 0)
 
   abstract class ObjectResource extends TypeMeta {
     def metadata: ObjectMeta


### PR DESCRIPTION
generation is a property that is needed in order to determine whether or not a deployments status is up to date.