### PR TITLE
Possible bug on creating a new Endpoint object

### DIFF
--- a/client/src/main/scala/skuber/Endpoints.scala
+++ b/client/src/main/scala/skuber/Endpoints.scala
@@ -6,7 +6,7 @@ import java.util.Date
  * @author David O'Riordan
  */
 case class Endpoints(
-  	val kind: String ="Endpoint",
+  	val kind: String ="Endpoints",
   	override val apiVersion: String = v1,
     val metadata: ObjectMeta,
     subsets: List[Endpoints.Subset] = Nil)       


### PR DESCRIPTION
I believe val kind: String = "Endpoint" should be "Endpoints". I've run into issues with constructing new instances of this class and I believe this is the cause. Is this a bug, or am I mistaken?