### PR TITLE
Add unavailableReplicas to Deployment.Status

### DIFF
--- a/client/src/main/scala/skuber/ext/Deployment.scala
+++ b/client/src/main/scala/skuber/ext/Deployment.scala
@@ -96,5 +96,6 @@ object Deployment {
       replicas: Int=0,
       updatedReplicas: Int=0,
       availableReplicas: Int = 0,
+      unavailableReplicas: Int = 0,
       observedGeneration: Int = 0)
 }

--- a/client/src/main/scala/skuber/json/ext/format/package.scala
+++ b/client/src/main/scala/skuber/json/ext/format/package.scala
@@ -55,6 +55,7 @@ package object format {
     (JsPath \ "replicas").formatMaybeEmptyInt() and
     (JsPath \ "updatedReplicas").formatMaybeEmptyInt() and
     (JsPath \ "availableReplicas").formatMaybeEmptyInt() and
+    (JsPath \ "unavailableReplicas").formatMaybeEmptyInt() and
     (JsPath \ "observedGeneration").formatMaybeEmptyInt()
   )(Deployment.Status.apply _, unlift(Deployment.Status.unapply))
   


### PR DESCRIPTION
The `unavailableReplicas` field was missing from the `Deployment.Status` model.