### PR TITLE
add rbac from 1.5

### DIFF
--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -92,7 +92,8 @@ package object client {
        val apiVersion = kind.apiVersion
        val usesExtensionsAPI = forExtensionsAPI.getOrElse(kind.isExtensionsKind)
        val usesBatchAPI = forExtensionsAPI.getOrElse(kind.isBatchKind)
-       val apiPrefix = if (usesExtensionsAPI || usesBatchAPI) "apis" else "api"
+       val usesRBACAPI = forExtensionsAPI.getOrElse(kind.isRBACKind)
+       val apiPrefix = if (usesExtensionsAPI || usesBatchAPI || usesRBACAPI) "apis" else "api"
 
          // helper to compose a full URL from a sequence of path components
        def mkUrlString(pathComponents: Option[String]*) : String = {
@@ -269,11 +270,14 @@ package object client {
      def isExtensionsKind: Boolean = false
      def isBatchKind: Boolean = false
      def isNamespaced: Boolean = true
+     def isRBACKind: Boolean = false
      def apiVersion: String =
        if (isExtensionsKind)
          skuber.ext.extensionsAPIVersion
        else if (isBatchKind)
          skuber.batch.batchAPIVersion
+       else if (isRBACKind)
+         skuber.rbac.rbacAPIVersion
        else
          "v1"
    }

--- a/client/src/main/scala/skuber/json/rbac/format/package.scala
+++ b/client/src/main/scala/skuber/json/rbac/format/package.scala
@@ -1,0 +1,65 @@
+package skuber.json.rbac
+
+import skuber._
+import skuber.rbac._
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+import skuber.json.format._ // reuse some core formatters
+
+/**
+  * Created by jordan on 1/13/17.
+  */
+package object format {
+
+  implicit val subjectFormat: Format[Subject] = (
+    (JsPath \ "apiVersion").formatNullable[String] and
+      (JsPath \ "kind").format[String] and
+      (JsPath \ "name").format[String] and
+      (JsPath \ "namespace").formatNullable[String]
+    )(Subject.apply _, unlift(Subject.unapply))
+
+  implicit val policyRuleFormat: Format[PolicyRule] = (
+    (JsPath \ "apiGroups").formatMaybeEmptyList[String] and
+    (JsPath \ "attributeRestrictions").formatNullable[String] and
+    (JsPath \ "nonResourceURLs").formatMaybeEmptyList[String] and
+    (JsPath \ "resourceNames").formatMaybeEmptyList[String] and
+    (JsPath \ "resources").formatMaybeEmptyList[String] and
+    (JsPath \ "verbs").formatMaybeEmptyList[String]
+  )(PolicyRule.apply _, unlift(PolicyRule.unapply))
+
+  implicit val roleFormat: Format[Role] = (
+    objFormat and
+    (JsPath \ "rules").formatMaybeEmptyList[PolicyRule]
+  )(Role.apply _, unlift(Role.unapply))
+
+
+  implicit val roleRefFormat: Format[RoleRef] = (
+    (JsPath \ "apiGroup").format[String] and
+    (JsPath \ "kind").format[String] and
+    (JsPath \ "name").format[String]
+  )(RoleRef.apply _, unlift(RoleRef.unapply))
+
+  implicit val clusterRoleBindingFormat: Format[ClusterRoleBinding] = (
+    objFormat and
+      (JsPath \ "roleRef").formatNullable[RoleRef] and
+      (JsPath \ "subjects").formatMaybeEmptyList[Subject]
+    )(ClusterRoleBinding.apply _, unlift(ClusterRoleBinding.unapply))
+
+  implicit val clusterRoleFormat: Format[ClusterRole] = (
+    objFormat and
+      (JsPath \ "rules").formatMaybeEmptyList[PolicyRule]
+    )(ClusterRole.apply _, unlift(ClusterRole.unapply))
+
+  implicit val roleBindingFormat: Format[RoleBinding] = (
+    objFormat and
+      (JsPath \ "roleRef").format[RoleRef] and
+      (JsPath \ "subjects").formatMaybeEmptyList[Subject]
+    )(RoleBinding.apply _, unlift(RoleBinding.unapply))
+
+  implicit val roleListFormat: Format[RoleList] = KListFormat[Role].apply(RoleList.apply _, unlift(RoleList.unapply))
+  implicit val roleBindingListFormat: Format[RoleBindingList] = KListFormat[RoleBinding].apply(RoleBindingList.apply _, unlift(RoleBindingList.unapply))
+  implicit val clusterRoleListFormat: Format[ClusterRoleList] = KListFormat[ClusterRole].apply(ClusterRoleList.apply _, unlift(ClusterRoleList.unapply))
+  implicit val clusterRoleBindingListFormat: Format[ClusterRoleBindingList] = KListFormat[ClusterRoleBinding].apply(ClusterRoleBindingList.apply _, unlift(ClusterRoleBindingList.unapply))
+}

--- a/client/src/main/scala/skuber/rbac/ClusterRole.scala
+++ b/client/src/main/scala/skuber/rbac/ClusterRole.scala
@@ -1,0 +1,15 @@
+package skuber.rbac
+
+import skuber.{ObjectMeta, ObjectResource}
+
+/**
+  * Created by jordan on 1/12/17.
+  */
+case class ClusterRole(
+    kind: String = "ClusterRole",
+    override val apiVersion: String = rbacAPIVersion,
+    metadata: ObjectMeta = ObjectMeta(),
+    rules: List[PolicyRule]
+) extends ObjectResource {
+
+}

--- a/client/src/main/scala/skuber/rbac/ClusterRoleBinding.scala
+++ b/client/src/main/scala/skuber/rbac/ClusterRoleBinding.scala
@@ -1,0 +1,16 @@
+package skuber.rbac
+
+import skuber.{ObjectMeta, ObjectResource}
+
+/**
+  * Created by jordan on 1/12/17.
+  */
+case class ClusterRoleBinding(
+    kind: String = "ClusterRoleBinding",
+    version: String = rbacAPIVersion,
+    metadata: ObjectMeta,
+    roleRef: Option[RoleRef],
+    subjects: List[Subject]
+) extends ObjectResource {
+
+}

--- a/client/src/main/scala/skuber/rbac/PolicyRule.scala
+++ b/client/src/main/scala/skuber/rbac/PolicyRule.scala
@@ -1,0 +1,15 @@
+package skuber.rbac
+
+/**
+  * Created by jordan on 1/12/17.
+  */
+case class PolicyRule(
+    apiGroups: List[String],
+    attributeRestrictions: Option[String],
+    nonResourceURLs: List[String],
+    resourceNames: List[String],
+    resources: List[String],
+    verbs: List[String]
+) {
+
+}

--- a/client/src/main/scala/skuber/rbac/Role.scala
+++ b/client/src/main/scala/skuber/rbac/Role.scala
@@ -1,0 +1,15 @@
+package skuber.rbac
+
+import skuber.{ObjectMeta, ObjectResource}
+
+/**
+  * Created by jordan on 1/12/17.
+  */
+case class Role(
+    kind: String = "Role",
+    version: String = rbacAPIVersion,
+    metadata: ObjectMeta,
+    rules: List[PolicyRule]
+) extends ObjectResource {
+
+}

--- a/client/src/main/scala/skuber/rbac/RoleBinding.scala
+++ b/client/src/main/scala/skuber/rbac/RoleBinding.scala
@@ -1,0 +1,16 @@
+package skuber.rbac
+
+import skuber.{ObjectMeta, ObjectResource}
+
+/**
+  * Created by jordan on 1/12/17.
+  */
+case class RoleBinding(
+    kind: String = "RoleBinding",
+    version: String = rbacAPIVersion,
+    metadata: ObjectMeta,
+    roleRef: RoleRef,
+    subjects: List[Subject]
+) extends ObjectResource {
+
+}

--- a/client/src/main/scala/skuber/rbac/RoleRef.scala
+++ b/client/src/main/scala/skuber/rbac/RoleRef.scala
@@ -1,0 +1,12 @@
+package skuber.rbac
+
+/**
+  * Created by jordan on 1/13/17.
+  */
+case class RoleRef(
+    apiGroup: String,
+    kind: String,
+    name: String
+) {
+
+}

--- a/client/src/main/scala/skuber/rbac/Subject.scala
+++ b/client/src/main/scala/skuber/rbac/Subject.scala
@@ -1,0 +1,13 @@
+package skuber.rbac
+
+/**
+  * Created by jordan on 1/13/17.
+  */
+case class Subject(
+    apiVersion: Option[String],
+    kind: String,
+    name: String,
+    namespace: Option[String]
+) {
+
+}

--- a/client/src/main/scala/skuber/rbac/package.scala
+++ b/client/src/main/scala/skuber/rbac/package.scala
@@ -1,0 +1,52 @@
+package skuber
+
+import skuber.api.client._
+import skuber.json.rbac.format._
+
+/**
+  * Created by jordan on 1/13/17.
+  */
+package object rbac {
+  val rbacAPIVersion = "rbac.authorization.k8s.io/v1alpha1"
+
+  trait isRBACKind[T <: TypeMeta] { self: Kind[T] =>
+    override def isRBACKind = true
+  }
+
+  implicit val clusterRoleKind: ObjKind[ClusterRole] = new ObjKind[ClusterRole]("clusterroles", "ClusterRole") with isRBACKind[ClusterRole] { override def isNamespaced: Boolean = false }
+
+  implicit val clusterRoleBindingKind: ObjKind[ClusterRoleBinding] = new ObjKind[ClusterRoleBinding]("clusterrolebindings", "ClusterRoleBinding") with isRBACKind[ClusterRoleBinding] { override def isNamespaced: Boolean = false }
+
+  implicit val roleKind: ObjKind[Role] = new ObjKind[Role]("roles", "Role") with isRBACKind[Role]
+
+  implicit val roleBindingKind: ObjKind[RoleBinding] = new ObjKind[RoleBinding]("rolebindings", "RoleBinding") with isRBACKind[RoleBinding]
+
+  case class ClusterRoleList(
+      val kind: String = "ClusterRoleList",
+      override val apiVersion: String = rbacAPIVersion,
+      val metadata: Option[ListMeta],
+      val items: List[ClusterRole]) extends KList[ClusterRole]
+  implicit val clusterRoleListKind = new ListKind[ClusterRoleList]("clusterroles") with isRBACKind[ClusterRoleList] { override def isNamespaced: Boolean = false }
+
+  case class ClusterRoleBindingList(
+      val kind: String = "ClusterRoleBindingList",
+      override val apiVersion: String = rbacAPIVersion,
+      val metadata: Option[ListMeta],
+      val items: List[ClusterRoleBinding]) extends KList[ClusterRoleBinding]
+  implicit val clusterRoleBindingListKind = new ListKind[ClusterRoleBindingList]("clusterrolebindings") with isRBACKind[ClusterRoleBindingList] { override def isNamespaced: Boolean = false }
+
+  case class RoleList(
+      val kind: String = "RoleList",
+      override val apiVersion: String = rbacAPIVersion,
+      val metadata: Option[ListMeta],
+      val items: List[Role]) extends KList[Role]
+  implicit val roleListKind = new ListKind[RoleList]("roles") with isRBACKind[RoleList]
+
+  case class RoleBindingList(
+      val kind: String = "RoleBindingList",
+      override val apiVersion: String = rbacAPIVersion,
+      val metadata: Option[ListMeta],
+      val items: List[RoleBinding]) extends KList[RoleBinding]
+  implicit val roleBindingListKind = new ListKind[RoleBindingList]("rolebindings") with isRBACKind[RoleBindingList]
+
+}


### PR DESCRIPTION
@coryfklein @doriordan 

This adds the rbac v1alpha1 objects that are now in kubernetes 1.5.
I have tested this against our cluster and it seems to be working.