### PR TITLE
Add NodeAffinity helpers

### DIFF
--- a/client/src/main/scala/skuber/annotation/NodeAffinity.scala
+++ b/client/src/main/scala/skuber/annotation/NodeAffinity.scala
@@ -1,0 +1,51 @@
+package skuber.annotation
+
+import skuber.annotation.NodeAffinity.{MatchExpressions, NodeSelectorTerms}
+
+/**
+  * Created by Cory Klein on 2/22/17.
+  */
+case class NodeAffinity(
+                    requiredDuringSchedulingIgnoredDuringExecution: Option[RequiredDuringSchedulingIgnoredDuringExecution],
+                    preferredDuringSchedulingIgnoredDuringExecution: Option[PreferredDuringSchedulingIgnoredDuringExecution]
+                  )
+
+object NodeAffinity {
+  val ANNOTATION_NAME = "scheduler.alpha.kubernetes.io/affinity"
+
+  type MatchExpressions = List[MatchExpression]
+  def MatchExpressions(xs: MatchExpression*) = List(xs: _*)
+
+  type NodeSelectorTerms = List[NodeSelectorTerm]
+  def NodeSelectorTerms(xs: NodeSelectorTerm*) = List(xs: _*)
+
+  def forRequiredQuery(key: String, operator: NodeAffinity.Operator.Value, values: List[String]): NodeAffinity = {
+    NodeAffinity(
+      Option(
+        RequiredDuringSchedulingIgnoredDuringExecution(
+          NodeSelectorTerms(
+            NodeSelectorTerm(
+              MatchExpressions(
+                MatchExpression(key, operator, values)
+              )
+            )
+          )
+        )
+      )
+      , None)
+  }
+
+  object Operator extends Enumeration {
+    type Operator = Value
+    val In, NotIn, Exists, DoesNotExist, Gt, Lt = Value
+  }
+}
+
+case class RequiredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms: NodeSelectorTerms)
+
+case class PreferredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms: NodeSelectorTerms)
+
+case class NodeSelectorTerm(matchExpressions: MatchExpressions)
+
+case class MatchExpression(key: String, operator: NodeAffinity.Operator.Value, values: List[String])
+

--- a/client/src/main/scala/skuber/json/annotation/format/package.scala
+++ b/client/src/main/scala/skuber/json/annotation/format/package.scala
@@ -1,0 +1,34 @@
+package skuber.json.annotation
+
+import play.api.libs.json._
+import skuber.annotation._
+import play.api.libs.functional.syntax._
+import skuber.annotation.NodeAffinity.{MatchExpressions, NodeSelectorTerms}
+import skuber.json.format._ // reuse some core formatters
+
+
+/**
+  * Created by Cory Klein on 2/22/17.
+  */
+package object format {
+
+  implicit val nodeAffinityOperatorFormat: Format[NodeAffinity.Operator.Operator] = Format(enumReads(NodeAffinity.Operator), enumWrites)
+
+  implicit val matchExpressionFormat: Format[MatchExpression] = (
+    (JsPath \ "key").formatMaybeEmptyString() and
+      (JsPath \ "operator").formatEnum(NodeAffinity.Operator) and
+      (JsPath \ "values").formatMaybeEmptyList[String]
+    )(MatchExpression.apply _, unlift(MatchExpression.unapply))
+
+  implicit val nodeSelectorTermFormat: Format[NodeSelectorTerm] = (
+    (JsPath \ "matchExpressions").format[MatchExpressions].inmap(matchExpressions => NodeSelectorTerm(matchExpressions), (nst: NodeSelectorTerm) => nst.matchExpressions)
+    )
+
+    implicit val requiredDuringSchedulingIgnoredDuringExecutionFormat: Format[RequiredDuringSchedulingIgnoredDuringExecution] = (
+      (JsPath \ "nodeSelectorTerms").format[NodeSelectorTerms].inmap(nodeSelectorTerms => RequiredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms), (rdside: RequiredDuringSchedulingIgnoredDuringExecution) => rdside.nodeSelectorTerms)
+    )
+
+    implicit val preferredDuringSchedulingIgnoredDuringExecutionFormat: Format[PreferredDuringSchedulingIgnoredDuringExecution] = (
+      (JsPath \ "nodeSelectorTerms").format[NodeSelectorTerms].inmap(nodeSelectorTerms => PreferredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms), (pdside: PreferredDuringSchedulingIgnoredDuringExecution) => pdside.nodeSelectorTerms)
+      )
+}

--- a/client/src/test/scala/skuber/json/annotation/NodeAffinitySpec.scala
+++ b/client/src/test/scala/skuber/json/annotation/NodeAffinitySpec.scala
@@ -1,0 +1,125 @@
+package skuber.json.annotation
+
+import org.specs2.mutable.Specification
+import play.api.libs.json._
+import skuber.annotation.NodeAffinity.{MatchExpressions, NodeSelectorTerms}
+import skuber.annotation._
+import skuber.json.annotation.format._
+
+/**
+  * Created by Cory Klein on 2/22/17.
+  */
+class NodeAffinitySpec extends Specification {
+  "This is a unit specification for the skuber formatter for k8s NodeAffinity.\n ".txt
+
+  private val operator = NodeAffinity.Operator.NotIn
+  private val operatorString = "\"NotIn\""
+
+  private val matchExpression = MatchExpression("disk", NodeAffinity.Operator.NotIn, List("hdd"))
+  private val matchExpressionString =
+    s"""{
+       |  "key": "disk",
+       |  "operator": $operatorString,
+       |  "values": ["hdd"]
+       |}""".stripMargin
+
+  private val matchExpressions: MatchExpressions = MatchExpressions(matchExpression)
+  private val matchExpressionsString =
+    s"""
+       |[ $matchExpressionString ]
+     """.stripMargin
+
+  private val nodeSelectorTerm = NodeSelectorTerm(matchExpressions)
+  private val nodeSelectorTermString =
+    s"""
+       |{
+       |  "matchExpressions": $matchExpressionsString
+       |}
+     """.stripMargin
+
+  private val nodeSelectorTerms: NodeSelectorTerms = NodeSelectorTerms(nodeSelectorTerm)
+  private val nodeSelectorTermsString =
+    s"""
+       |[ $nodeSelectorTermString ]
+     """.stripMargin
+
+  private val requiredDuringSchedulingIgnoredDuringExecution = RequiredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms)
+  private val requiredDuringSchedulingIgnoredDuringExecutionString =
+    s"""
+       |{
+       |  "nodeSelectorTerms": $nodeSelectorTermsString
+       |}
+     """.stripMargin
+
+  private val preferredDuringSchedulingIgnoredDuringExecution = PreferredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms)
+  private val preferredDuringSchedulingIgnoredDuringExecutionString =
+    s"""
+       |{
+       |  "nodeSelectorTerms": $nodeSelectorTermsString
+       |}
+     """.stripMargin
+
+
+  "An Operator can be written to json and back in \n" >> {
+    val expectedJson = Json.parse("\"" + operator.toString + "\"")
+    val serializedOperatorJson = Json.toJson(operator)
+    serializedOperatorJson mustEqual expectedJson
+
+    val deserializedOperator = Json.fromJson[NodeAffinity.Operator.Value](serializedOperatorJson).get
+    deserializedOperator mustEqual operator
+  }
+
+  "A MatchExpression can be written to json and back in \n" >> {
+    val expectedJson = Json.parse(matchExpressionString)
+    val serializedMatchExpressionJson = Json.toJson(matchExpression)
+    serializedMatchExpressionJson mustEqual expectedJson
+
+    val deserializedMatchExpression = Json.fromJson[MatchExpression](serializedMatchExpressionJson).get
+    deserializedMatchExpression mustEqual matchExpression
+  }
+
+  "A MatchExpressions can be written to json and back in \n" >> {
+    val expectedJson = Json.parse(matchExpressionsString)
+    val serializedMatchExpressionsJson = Json.toJson(matchExpressions)
+    serializedMatchExpressionsJson mustEqual expectedJson
+
+    val deserializedMatchExpressions = Json.fromJson[MatchExpressions](serializedMatchExpressionsJson).get
+    deserializedMatchExpressions mustEqual matchExpressions
+  }
+
+  "A NodeSelectorTerm can be written to json and back in \n" >> {
+    val expectedJson = Json.parse(nodeSelectorTermString)
+    val serializedNodeSelectorTermJson = Json.toJson(nodeSelectorTerm)
+    serializedNodeSelectorTermJson mustEqual expectedJson
+
+    val deserializedNodeSelectorTerm = Json.fromJson[NodeSelectorTerm](serializedNodeSelectorTermJson).get
+    deserializedNodeSelectorTerm mustEqual nodeSelectorTerm
+  }
+
+  "A NodeSelectorTerms can be written to json and back in \n" >> {
+    val expectedJson = Json.parse(nodeSelectorTermsString)
+    val serializedNodeSelectorTermsJson = Json.toJson(nodeSelectorTerms)
+    serializedNodeSelectorTermsJson mustEqual expectedJson
+
+    val deserializedNodeSelectorTerms = Json.fromJson[NodeSelectorTerms](serializedNodeSelectorTermsJson).get
+    deserializedNodeSelectorTerms mustEqual nodeSelectorTerms
+  }
+
+  "A RequiredDuringSchedulingIgnoredDuringExecution can be written to json and back in \n" >> {
+    val expectedJson = Json.parse(requiredDuringSchedulingIgnoredDuringExecutionString)
+    val serializedRequiredDuringSchedulingIgnoredDuringExecutionJson = Json.toJson(requiredDuringSchedulingIgnoredDuringExecution)
+    serializedRequiredDuringSchedulingIgnoredDuringExecutionJson mustEqual expectedJson
+
+    val deserializedRequiredDuringSchedulingIgnoredDuringExecution = Json.fromJson[RequiredDuringSchedulingIgnoredDuringExecution](serializedRequiredDuringSchedulingIgnoredDuringExecutionJson).get
+    deserializedRequiredDuringSchedulingIgnoredDuringExecution mustEqual requiredDuringSchedulingIgnoredDuringExecution
+  }
+
+  "A PreferredDuringSchedulingIgnoredDuringExecution can be written to json and back in \n" >> {
+    val expectedJson = Json.parse(preferredDuringSchedulingIgnoredDuringExecutionString)
+    val serializedPreferredDuringSchedulingIgnoredDuringExecutionJson = Json.toJson(preferredDuringSchedulingIgnoredDuringExecution)
+    serializedPreferredDuringSchedulingIgnoredDuringExecutionJson mustEqual expectedJson
+
+    val deserializedPreferredDuringSchedulingIgnoredDuringExecution = Json.fromJson[PreferredDuringSchedulingIgnoredDuringExecution](serializedPreferredDuringSchedulingIgnoredDuringExecutionJson).get
+    deserializedPreferredDuringSchedulingIgnoredDuringExecution mustEqual preferredDuringSchedulingIgnoredDuringExecution
+  }
+}


### PR DESCRIPTION
Kubernetes has introduced an alpha Node Affinity here:

https://kubernetes.io/docs/user-guide/node-selection/

This will replace the node selector. Since the node affinity selectors
are implemented as free-form annotation string fields, these
NodeAffinity and related classes are not part of the normal
object/annotation hierarchy, rather they are helper classes for creating
JSON strings that match the node affinity you want to create.