### PR TITLE
Use the apis prefix for StatefulSet

### DIFF
--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -93,9 +93,10 @@ package object client {
        val usesExtensionsAPI = forExtensionsAPI.getOrElse(kind.isExtensionsKind)
        val usesBatchAPI = forExtensionsAPI.getOrElse(kind.isBatchKind)
        val usesRBACAPI = forExtensionsAPI.getOrElse(kind.isRBACKind)
-       val apiPrefix = if (usesExtensionsAPI || usesBatchAPI || usesRBACAPI) "apis" else "api"
+       val usesAppsAPI = forExtensionsAPI.getOrElse(kind.isAppsKind)
+       val apiPrefix = if (usesExtensionsAPI || usesBatchAPI || usesRBACAPI || usesAppsAPI) "apis" else "api"
 
-         // helper to compose a full URL from a sequence of path components
+       // helper to compose a full URL from a sequence of path components
        def mkUrlString(pathComponents: Option[String]*) : String = {
          pathComponents.foldLeft("")((acc,next) => next match {
            case None => acc


### PR DESCRIPTION
This fixes an error when trying to run operations on a StatefulSet resource. See below using `kubectl v1.6.0`:

```
2017-06-26 18:04:02 INFO  api:138 - [Skuber Request: method=GET,url=http://localhost:8001/api/apps/v1beta1/namespaces/default/statefulsets/my-statefulset]
2017-06-26 18:04:03 WARN  api:378 - [Skuber Response: non-ok status returned = Status(v1,Status,ListMeta(,),Some(Failure),Some(the server could not find the requested resource),Some(NotFound),Some({}),Some(404))
```

When retrieving a StatefulSet, the correct API endpoint is at `apis`, not `api`. This PR resolves this error, so that the logs now look like this:

```
2017-06-26 18:31:47 INFO  api:139 - [Skuber Request: method=GET,url=http://localhost:8001/apis/apps/v1beta1/namespaces/default/statefulsets/my-statefulset]
2017-06-26 18:31:47 INFO  api:360 - [Skuber Response: successfully parsed StatefulSet(StatefulSet,apps/v1beta1,ObjectMeta(...
```
The usage in the code looks like this:

```
val statefulSetName = "my-statefulset"
val resource: Future[StatefulSet] = k8s get[StatefulSet] statefulSetName
```