### PR TITLE
expose methods to pass in own client

### DIFF
--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -2,8 +2,10 @@
 import java.net.URL
 import java.util.Date
 
-import scala.collection.immutable.HashMap
+import play.api.libs.ws.ning.NingWSClient
+import skuber.api.client.Context
 
+import scala.collection.immutable.HashMap
 import scala.language.implicitConversions
 
 import scala.concurrent.ExecutionContext
@@ -247,5 +249,7 @@ package object skuber {
   
   def k8sInit(implicit executionContext: ExecutionContext)  = skuber.api.client.init
   def k8sInit(config: skuber.api.Configuration)(implicit executionContext : ExecutionContext) = skuber.api.client.init(config)
-      
+  def k8sInit(config: skuber.api.Configuration, httpClient: NingWSClient)(implicit executionContext : ExecutionContext) = skuber.api.client.init(config, httpClient)
+  def createDefaultHttpClient(k8sContext: Context): NingWSClient = skuber.api.client.createDefaultHttpClient(k8sContext)
+
 }


### PR DESCRIPTION
Currently while using skuber we have a massive thread leak that results from us having 100s of namespaces. Currently skuber creates a new http client for each namespaced client that is created. We would like to intern our clients and only create one per cluster we are pointing to. Then just pass in that same client every time we create a new skuber client.

@doriordan What are your thoughts on this?