### PR TITLE
Upgrade to Play 2.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-val playws = "com.typesafe.play" %% "play-ws" % "2.4.8"
-val playtest = "com.typesafe.play" %% "play-test" % "2.4.8"
+val playws = "com.typesafe.play" %% "play-ws" % "2.5.14"
+val playtest = "com.typesafe.play" %% "play-test" % "2.5.14"
 val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.4"
 val specs2 = "org.specs2" %% "specs2-core" % "3.7"
 val snakeYaml =  "org.yaml" % "snakeyaml" % "1.16"
 val commonsIO = "commons-io" % "commons-io" % "2.4"
-val playIterateesExtra = "com.typesafe.play.extras" %% "iteratees-extras" % "1.5.0"
-val mockws = "de.leanovate.play-mockws" %% "play-mockws" % "2.4.2"
+val playIterateesExtra = "com.typesafe.play.extras" %% "iteratees-extras" % "1.6.0"
+val mockws = "de.leanovate.play-mockws" %% "play-mockws" % "2.5.1"
 
 
 // Akka is required by the examples

--- a/client/src/main/scala/skuber/api/Watch.scala
+++ b/client/src/main/scala/skuber/api/Watch.scala
@@ -43,7 +43,7 @@ object Watch {
        if (log.isDebugEnabled) 
          log.debug("[Skuber Watch (" + name + "): creating...")
        val wsReq = context.buildRequest(Some(name), watch=true)(kind).
-                               withRequestTimeout(2147483647)
+                               withRequestTimeout(Duration.Inf)
        val maybeResourceVersionParam = sinceResourceVersion map { "resourceVersion" -> _ }
        val watchRequest = maybeResourceVersionParam map { wsReq.withQueryString(_) } getOrElse(wsReq)
        val (responseBytesIteratee, responseBytesEnumerator) = Concurrent.joined[Array[Byte]]
@@ -62,7 +62,7 @@ object Watch {
         if (log.isDebugEnabled) 
           log.debug("[Skuber Watch (" + watchId + ") : creating...")
         val wsReq = context.buildRequest(None, watch=true)(kind).
-                              withRequestTimeout(2147483647)
+                              withRequestTimeout(Duration.Inf)
                                  
         val maybeResourceVersionParam = sinceResourceVersion map { "resourceVersion" -> _ }
         val watchRequest = maybeResourceVersionParam map { wsReq.withQueryString(_) } getOrElse(wsReq)

--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -2,10 +2,11 @@
 import java.net.URL
 import java.util.Date
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
 import scala.collection.immutable.HashMap
-
 import scala.language.implicitConversions
-
 import scala.concurrent.ExecutionContext
 
 /*
@@ -245,7 +246,7 @@ package object skuber {
   type K8SWatch[O] = skuber.api.Watch[O] 
   type K8SWatchEvent[I <: ObjectResource] = skuber.api.client.WatchEvent[I]
   
-  def k8sInit(implicit executionContext: ExecutionContext)  = skuber.api.client.init
-  def k8sInit(config: skuber.api.Configuration)(implicit executionContext : ExecutionContext) = skuber.api.client.init(config)
+  def k8sInit(implicit executionContext: ExecutionContext, system: ActorSystem, materializer: ActorMaterializer)  = skuber.api.client.init
+  def k8sInit(config: skuber.api.Configuration)(implicit executionContext : ExecutionContext, system: ActorSystem, materializer: ActorMaterializer) = skuber.api.client.init(config)
       
 }

--- a/client/src/test/scala/skuber/api/WatchSpec.scala
+++ b/client/src/test/scala/skuber/api/WatchSpec.scala
@@ -19,7 +19,6 @@ import play.api.libs.iteratee.{Enumerator,Iteratee}
  * @author David O'Riordan
  */
 class WatchSpec extends Specification {
-  import play.api.libs.iteratee.Execution.Implicits.trampoline
   
   "A single chunk containing a single Watch event can be enumerated correctly" >> {
     val eventsAsStr =  """{"type":"MODIFIED","object":{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"frontend","namespace":"default","selfLink":"/api/v1/namespaces/default/replicationcontrollers/frontend","uid":"246f12b6-719b-11e5-89ae-0800279dd272","resourceVersion":"12803","generation":2,"creationTimestamp":"2015-10-13T11:11:24Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":3,"observedGeneration":2}}}"""

--- a/examples/src/main/scala/skuber/examples/deployment/DeploymentExamples.scala
+++ b/examples/src/main/scala/skuber/examples/deployment/DeploymentExamples.scala
@@ -1,5 +1,7 @@
 package skuber.examples.deployment
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import skuber._
 import skuber.json.format._
 import skuber.ext._
@@ -26,10 +28,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
  * the deployment update is being processed.
  */
 object DeploymentExamples extends App {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
  
   val k8s = k8sInit
   
-  val deployment = deployNginx("1.7.9") 
+  val deployment = deployNginx("1.7.9")
   
   deployment onSuccess {
     case depl => 

--- a/examples/src/main/scala/skuber/examples/fluent/FluentExamples.scala
+++ b/examples/src/main/scala/skuber/examples/fluent/FluentExamples.scala
@@ -1,5 +1,7 @@
 package skuber.examples.fluent
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import skuber._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -16,6 +18,8 @@ import skuber.json.format._
  * 
  */
 object FluentExamples extends App {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
   
   val image = "nginx"
   val namePrefix = "nginx"

--- a/examples/src/main/scala/skuber/examples/guestbook/KubernetesProxyActor.scala
+++ b/examples/src/main/scala/skuber/examples/guestbook/KubernetesProxyActor.scala
@@ -2,19 +2,15 @@ package skuber.examples.guestbook
 
 import skuber._
 import skuber.json.format._
-
-import akka.actor.{Actor, ActorRef, ActorLogging}
-import akka.actor.Props
-import akka.event.{LoggingReceive}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props}
+import akka.event.LoggingReceive
 import akka.pattern.pipe
+import akka.stream.ActorMaterializer
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-
-import scala.util.{Success, Failure}
-
+import scala.util.{Failure, Success}
 import scala.collection._
-
 import play.api.libs.iteratee.Iteratee
 
 /**
@@ -52,6 +48,8 @@ object KubernetesProxyActor {
 }
 
 class KubernetesProxyActor extends Actor with ActorLogging {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
 
   val k8s = k8sInit // initialize skuber client (request context)
   var rcWatching = mutable.HashMap[String, Watching]()

--- a/examples/src/main/scala/skuber/examples/ingress/NginxIngress.scala
+++ b/examples/src/main/scala/skuber/examples/ingress/NginxIngress.scala
@@ -2,8 +2,10 @@ package skuber.examples.ingress
 
 import java.net.HttpURLConnection
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import skuber._
-import skuber.ext.{Ingress,ReplicaSet}
+import skuber.ext.{Ingress, ReplicaSet}
 
 import scala.annotation.tailrec
 
@@ -19,6 +21,8 @@ import skuber.json.ext.format._
   */
 
 object NginxIngress extends App {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
 
   val httpPort=80
   val httpsPort=443

--- a/examples/src/main/scala/skuber/examples/job/PrintPiJob.scala
+++ b/examples/src/main/scala/skuber/examples/job/PrintPiJob.scala
@@ -1,12 +1,14 @@
 package skuber.examples.job
 
-import skuber.{k8sInit, Pod, Container, RestartPolicy}
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import skuber.{Container, Pod, RestartPolicy, k8sInit}
 import skuber.batch.Job
 import skuber.json.batch.format._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 
 /**
  * @author David O'Riordan
@@ -15,6 +17,8 @@ import scala.util.{Success, Failure}
  * Starts a Job on Kubernetes that prints pi to 2000 decimal places
  */
 object PrintPiJob extends App {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
 
   val k8s = k8sInit
 

--- a/examples/src/main/scala/skuber/examples/list/ListExamples.scala
+++ b/examples/src/main/scala/skuber/examples/list/ListExamples.scala
@@ -1,5 +1,7 @@
 package skuber.examples.list
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import skuber.Pod.Phase
 import skuber._
 
@@ -34,7 +36,10 @@ object ListExamples extends App {
       System.out.println(f"${name}%-50s${ns}%-20s${phase}")
     }
   }
-  
+
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+
   val k8s = k8sInit
 
   System.out.println("\nGetting list of pods in namespace of current context ==>")

--- a/examples/src/main/scala/skuber/examples/scale/ScaleExamples.scala
+++ b/examples/src/main/scala/skuber/examples/scale/ScaleExamples.scala
@@ -1,9 +1,12 @@
 package skuber.examples.scale
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import skuber._
 import skuber.json.format._
 import skuber.ext._
 import skuber.json.ext.format._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
@@ -21,6 +24,8 @@ object ScaleExamples extends App {
     val nginxController= ReplicationController("nginx-scale-example",nginxContainer,nginxSelector).withReplicas(5)
    
     import scala.concurrent.ExecutionContext.Implicits.global
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
     val k8s = k8sInit
   
     println("Creating nginx replication controller")

--- a/examples/src/main/scala/skuber/examples/watch/WatchExamples.scala
+++ b/examples/src/main/scala/skuber/examples/watch/WatchExamples.scala
@@ -1,16 +1,19 @@
 package skuber.examples.watch
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import skuber._
 import skuber.json.format._
-  
-import scala.concurrent.ExecutionContext.Implicits.global
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.libs.iteratee.Iteratee
 
 /**
  * @author David O'Riordan
  */
 object WatchExamples {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
   
   def  watchFrontEndScaling = {
      val k8s = k8sInit    


### PR DESCRIPTION
This pull request upgrades the Play dependency to 2.5.

Would you be interested in dropping Play altogether and migrate to Akka Http & Streams? That seems the best path to add Scala 2.12 support.