### PR TITLE
Failure and success threshold in readiness and liveness probes

### DIFF
--- a/client/src/main/scala/skuber/Container.scala
+++ b/client/src/main/scala/skuber/Container.scala
@@ -70,11 +70,13 @@ case class Container(
   def withHttpLivenessProbe(
     path: String,
     port: NameablePort = 80,
-    initialDelaySeconds:Int = 0,
-    timeoutSeconds:Int = 0,
+    initialDelaySeconds: Int = 0,
+    timeoutSeconds: Int = 0,
+    successThreshold: Int = 1,
+    failureThreshold: Int = 3,
     schema: String = "HTTP") = {
     val handler = HTTPGetAction(port = port, path = path, schema = schema)
-    val probe = Probe(handler, initialDelaySeconds, timeoutSeconds)
+    val probe = Probe(handler, initialDelaySeconds, timeoutSeconds, successThreshold, failureThreshold)
     withLivenessProbe(probe)
   }
   def withReadinessProbe(probe:Probe) =
@@ -84,9 +86,11 @@ case class Container(
     port: NameablePort = 80,
     initialDelaySeconds:Int = 0,
     timeoutSeconds:Int = 0,
+    successThreshold: Int = 1,
+    failureThreshold: Int = 3,
     schema: String = "HTTP") = {
     val handler = HTTPGetAction(port = port, path = path, schema = schema)
-    val probe = Probe(handler, initialDelaySeconds, timeoutSeconds)
+    val probe = Probe(handler, initialDelaySeconds, timeoutSeconds, successThreshold, failureThreshold)
     withReadinessProbe(probe)
   }
 

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -289,8 +289,10 @@ package object format {
   implicit val probeFormat : Format[Probe] = (
     JsPath.format[Handler] and
     (JsPath \ "initialDelaySeconds").formatMaybeEmptyInt() and
-    (JsPath \ "timeoutSeconds").formatMaybeEmptyInt()
-  )(Probe.apply _, unlift(Probe.unapply))
+    (JsPath \ "timeoutSeconds").formatMaybeEmptyInt() and
+    (JsPath \ "successThreshold").formatMaybeEmptyInt() and
+    (JsPath \ "failureThreshold").formatMaybeEmptyInt()
+    )(Probe.apply _, unlift(Probe.unapply))
   
   
   implicit val lifecycleFormat: Format[Lifecycle] = Json.format[Lifecycle]

--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -211,7 +211,9 @@ package object skuber {
   // TCP endpoint - health check succeeds if can connect to it
   case class TCPSocketAction(port: NameablePort) extends Handler
   
-  case class Probe(action: Handler, initialDelaySeconds: Int = 0, timeoutSeconds: Int = 0)
+  case class Probe(action: Handler, initialDelaySeconds: Int = 0, timeoutSeconds: Int = 0,
+                   successThreshold: Int = 1, failureThreshold: Int = 3)
+
   case class Lifecycle(postStart: Option[Handler] = None, preStop: Option[Handler] = None) 
   
   case class WatchedEvent(eventType: WatchedEventType.Value, eventObject: ObjectResource)

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -214,7 +214,9 @@ import Pod._
                     ]
                   },
                   "initialDelaySeconds": 30,
-                  "timeoutSeconds": 5
+                  "timeoutSeconds": 5,
+                  "successThreshold": 1,
+                  "failureThreshold": 3
                 },
                 "terminationMessagePath": "/dev/termination-log",
                 "imagePullPolicy": "IfNotPresent"
@@ -320,6 +322,8 @@ import Pod._
       }
       probe.initialDelaySeconds mustEqual 30
       probe.timeoutSeconds mustEqual 5
+      probe.failureThreshold mustEqual 3
+      probe.successThreshold mustEqual 1
       
       val ports = cntrs(2).ports // skyDNS ports
       ports.length mustEqual 2


### PR DESCRIPTION
# Description

Readiness and liveness probes are supported without `successThreshold` and `failureThreshold`, which are required in some cases.

# Solution

Extend  probe with `successThreshold` and `failureThreshold`.