### PR TITLE
add support for jwt auth

### DIFF
--- a/client/src/main/scala/skuber/api/Configuration.scala
+++ b/client/src/main/scala/skuber/api/Configuration.scala
@@ -86,6 +86,7 @@ object Configuration {
         def topLevelYamlToK8SConfigMap[K8SConfigKind](kind: String, toK8SConfig: YamlMap=> K8SConfigKind) =
           topLevelList(kind + "s").asScala.map(item => name(item) -> toK8SConfig(child(item, kind))).toMap
 
+
         def toK8SCluster(clusterConfig: YamlMap) =
           Cluster(
             apiVersion=valueAt(clusterConfig, "api-version", Some("v1")),
@@ -96,13 +97,13 @@ object Configuration {
 
         val k8sClusterMap = topLevelYamlToK8SConfigMap("cluster", toK8SCluster _)
 
-        def toK8SAuthInfo(userConfig:YamlMap) =
-          AuthInfo(
-            clientCertificate=pathOrDataValueAt(userConfig, "client-certificate","client-certificate-data"),
-            clientKey=pathOrDataValueAt(userConfig, "client-key","client-key-data"),
-            token=optionalValueAt(userConfig, "token"),
-            userName=optionalValueAt(userConfig, "username"),
-            password=optionalValueAt(userConfig, "password"))
+        def toK8SAuthInfo(userConfig:YamlMap):AuthInfo = AuthInfo(
+          clientCertificate = pathOrDataValueAt(userConfig, "client-certificate", "client-certificate-data"),
+          clientKey = pathOrDataValueAt(userConfig, "client-key", "client-key-data"),
+          jwt = optionalValueAt(child(child(userConfig, "auth-provider"),"config"), "id-token"),
+          token = optionalValueAt(userConfig, "token"),
+          userName = optionalValueAt(userConfig, "username"),
+          password = optionalValueAt(userConfig, "password"))
 
         val k8sAuthInfoMap = topLevelYamlToK8SConfigMap("user", toK8SAuthInfo _)
 

--- a/client/src/main/scala/skuber/api/Configuration.scala
+++ b/client/src/main/scala/skuber/api/Configuration.scala
@@ -2,13 +2,13 @@ package skuber.api
 
 import client._
 import skuber.Namespace
-import scala.util.{Try,Success,Failure}
+
+import scala.util.{Failure, Success, Try}
 import java.io.{File, FileInputStream}
 
 import scala.collection.JavaConverters._
 import org.yaml.snakeyaml.Yaml
-
-import java.util.Base64
+import java.util.{Base64, Collections}
 
 /**
  * @author David O'Riordan
@@ -100,7 +100,13 @@ object Configuration {
         def toK8SAuthInfo(userConfig:YamlMap):AuthInfo = AuthInfo(
           clientCertificate = pathOrDataValueAt(userConfig, "client-certificate", "client-certificate-data"),
           clientKey = pathOrDataValueAt(userConfig, "client-key", "client-key-data"),
-          jwt = optionalValueAt(child(child(userConfig, "auth-provider"),"config"), "id-token"),
+          jwt = userConfig.containsKey("auth-provider") match {
+            case true => val authProvider = child(userConfig,"auth-provider"); authProvider.containsKey("config") match {
+              case true => val config = child(authProvider,"config"); optionalValueAt(config,"id-token")
+              case false => None
+            }
+            case false => None
+          },
           token = optionalValueAt(userConfig, "token"),
           userName = optionalValueAt(userConfig, "username"),
           password = optionalValueAt(userConfig, "password"))

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -42,6 +42,7 @@ package object client {
    case class AuthInfo(
      clientCertificate: Option[PathOrData] = None,
      clientKey: Option[PathOrData] = None,
+     jwt: Option[String] = None,
      token: Option[String] = None,
      userName: Option[String] = None,
      password: Option[String] = None
@@ -56,6 +57,7 @@ package object client {
          case Left(certPath: String) => "clientKey=" + certPath + " "
          case Right(_: Array[Byte]) => "clientKey=<PEM masked> "
        }).getOrElse("")
+       result ++= jwt.map("jwt="+_.replaceAll(".","*")+" ").getOrElse("")
        result ++= token.map("token="+_.replaceAll(".","*")+" ").getOrElse("")
        result ++= userName.map("userName="+_+" ").getOrElse("")
        result ++= password.map("password="+_.replaceAll(".","*")+" ").getOrElse("")

--- a/client/src/main/scala/skuber/api/security/HTTPRequestAuth.scala
+++ b/client/src/main/scala/skuber/api/security/HTTPRequestAuth.scala
@@ -18,14 +18,16 @@ object HTTPRequestAuth {
   
   def establishRequestAuth(k8sContext: Context) : RequestAuth = {
     val maybeToken=k8sContext.authInfo.token
+    val maybeJWT=k8sContext.authInfo.jwt
     val maybeUserName=k8sContext.authInfo.userName
     val maybePassword=k8sContext.authInfo.password
-    (maybeToken, maybeUserName, maybePassword) match {
-      case (None, None, None) => NoAuth 
-      case (Some(token), None, None) => Token(token)
-      case (None, Some(userName), Some(password)) => BasicAuth(userName, password)
-      case (None, Some(userName), None) => throw new Exception("No password provided for user " + userName)
-      case (None, None, Some(password)) => throw new Exception("Password provided but no username found for user")
+    (maybeToken, maybeUserName, maybePassword,maybeJWT) match {
+      case (None, None, None, None) => NoAuth
+      case (Some(token), None, None, None) => Token(token)
+      case (None, None, None,Some(token)) => Token(token)
+      case (None, Some(userName), Some(password), None) => BasicAuth(userName, password)
+      case (None, Some(userName), None, None) => throw new Exception("No password provided for user " + userName)
+      case (None, None, Some(password), None) => throw new Exception("Password provided but no username found for user")
       case _ => throw new Exception("Only one of token or username/password may be specified")
     }
   }

--- a/client/src/test/scala/skuber/api/ConfigurationSpec.scala
+++ b/client/src/test/scala/skuber/api/ConfigurationSpec.scala
@@ -50,6 +50,18 @@ users:
   user:
     client-certificate: path/to/my/client/cert
     client-key: path/to/my/client/key
+- name: jwt-user
+  user:
+    auth-provider:
+      config:
+        client-id: tectonic
+        client-secret: secret
+        extra-scopes: groups
+        id-token: jwt-token
+        idp-certificate-authority-data: data
+        idp-issuer-url: https://xyz/identity
+        refresh-token: refresh
+      name: oidc
 """
     val is = new java.io.ByteArrayInputStream(kubeConfigStr.getBytes(java.nio.charset.Charset.forName("UTF-8")))
     val k8sConfig = K8SConfiguration.parseKubeconfigStream(is)
@@ -63,8 +75,9 @@ users:
     val clusters=Map("cow-cluster" -> cowCluster,"horse-cluster"->horseCluster,"pig-cluster"->pigCluster)
     
     val blueUser=K8SAuthInfo(token=Some("blue-token"))
-    val greenUser=K8SAuthInfo(clientCertificate=Some(Left("path/to/my/client/cert")), clientKey=Some(Left("path/to/my/client/key")))    
-    val users=Map("blue-user"->blueUser,"green-user"->greenUser)
+    val greenUser=K8SAuthInfo(clientCertificate=Some(Left("path/to/my/client/cert")), clientKey=Some(Left("path/to/my/client/key")))
+    val jwtUser=K8SAuthInfo(jwt = Some("jwt-token"))
+    val users=Map("blue-user"->blueUser,"green-user"->greenUser,"jwt-user"->jwtUser)
 
     val federalContext=K8SContext(horseCluster,greenUser,Namespace.forName("chisel-ns"))
     val queenAnneContext=K8SContext(pigCluster,blueUser, Namespace.forName("saw-ns"))


### PR DESCRIPTION
adding support for jwt auth so that the library can be used with tectonic clusters
```
users:
- name: tectonic
  user:
    auth-provider:
      config:
        client-id: tectonic
        client-secret: *******
        extra-scopes: groups
        id-token: 
        idp-certificate-authority-data: 
        idp-issuer-url: https://xyz/identity
        refresh-token: 
       name: oidc
```