### PR TITLE
Pre 1.6 deployment

### DIFF
--- a/client/src/main/scala/skuber/ext/Deployment.scala
+++ b/client/src/main/scala/skuber/ext/Deployment.scala
@@ -1,0 +1,120 @@
+package skuber.ext
+
+/**
+ * @author David O'Riordan
+ */
+
+import skuber.ResourceSpecification.{Names, Scope}
+import skuber.{Container, IntOrString, LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, Pod, ListResource, ResourceDefinition}
+
+case class Deployment(
+    val kind: String ="Deployment",
+    override val apiVersion: String = extensionsAPIVersion,
+    val metadata: ObjectMeta = ObjectMeta(),
+    val spec:  Option[Deployment.Spec] = None,
+    val status: Option[Deployment.Status] = None)
+      extends ObjectResource {
+
+  def withResourceVersion(version: String): Deployment = this.copy(metadata = metadata.copy(resourceVersion = version))
+
+  lazy val copySpec: skuber.ext.Deployment.Spec = this.spec.getOrElse(new Deployment.Spec)
+
+  def withReplicas(count: Int): Deployment = this.copy(spec = Some(copySpec.copy(replicas = Some(count))))
+
+  def withTemplate(template: Pod.Template.Spec): Deployment = this.copy(spec = Some(copySpec.copy(template = Some(template))))
+
+  def withLabelSelector(sel: LabelSelector): Deployment = this.copy(spec = Some(copySpec.copy(selector = Some(sel))))
+
+  def getPodSpec: Option[Pod.Spec] = for {
+    spec <- this.spec
+    template <- spec.template
+    spec <- template.spec
+  } yield spec
+
+  /*
+   * A common deployment upgrade scenario would be to add or upgrade a single container e.g. update to a new image version
+   * This supports that by adding the specified container if one of same name not specified already, or just replacing
+   * the existing one of the same name if applicable. 
+   * The modified Deployment can then be updated on Kubernetes to instigate the upgrade.  
+   */
+  def updateContainer(newContainer: Container): Deployment = {
+    val containers = getPodSpec map {
+      _.containers
+    }
+    val updatedContainers = containers map { list =>
+      val existing = list.find(_.name == newContainer.name)
+      existing match {
+        case Some(_) => list.collect {
+          case c if c.name == newContainer.name => newContainer
+          case c => c
+        }
+        case None => newContainer :: list
+      }
+    }
+    val newContainerList = updatedContainers.getOrElse(List(newContainer))
+    val updatedPodSpec = getPodSpec.getOrElse(Pod.Spec())
+    val newPodSpec = updatedPodSpec.copy(containers = newContainerList)
+    val updatedTemplate: Pod.Template.Spec = copySpec.template.getOrElse(Pod.Template.Spec()).copy(spec = Some(newPodSpec))
+
+    this.copy(spec = Some(copySpec.copy(template = Some(updatedTemplate))))
+  }
+}
+
+object Deployment {
+
+  val specification=NonCoreResourceSpecification (
+    group=Some("extensions"),
+    version="v1beta1",
+    scope = Scope.Namespaced,
+    names=Names(
+      plural = "deployments",
+      singular = "deployment",
+      kind = "Deployment",
+      shortNames = List("deploy")
+    )
+  )
+  implicit val deployDef: ResourceDefinition[Deployment] = new ResourceDefinition[Deployment] { def spec=specification }
+  implicit val deployListDef: ResourceDefinition[ListResource[Deployment]] =  new ResourceDefinition[ListResource[Deployment]] { def spec=specification }
+
+  def apply(name: String) = new Deployment(metadata=ObjectMeta(name=name))
+  
+  case class Spec(
+    replicas: Option[Int] = Some(1),
+    selector: Option[LabelSelector] = None,
+    template: Option[Pod.Template.Spec] = None,
+    strategy: Option[Strategy] = None,
+    minReadySeconds: Int = 0) {
+    
+    def getStrategy: Strategy = strategy.getOrElse(Strategy.apply)
+  }
+    
+  object StrategyType extends Enumeration {
+    type StrategyType = Value
+    val Recreate, RollingUpdate = Value
+  }
+   
+  sealed trait Strategy {
+      def _type: StrategyType.StrategyType
+      def rollingUpdate: Option[RollingUpdate]
+  }
+  
+  object Strategy {
+    private[skuber] case class StrategyImpl(_type: StrategyType.StrategyType, rollingUpdate: Option[RollingUpdate]) extends Strategy
+    def apply: Strategy = StrategyImpl(_type=StrategyType.Recreate, rollingUpdate=None)
+    def apply(_type: StrategyType.StrategyType,rollingUpdate: Option[RollingUpdate]) : Strategy = StrategyImpl(_type, rollingUpdate)
+    def apply(rollingUpdate: RollingUpdate) : Strategy = StrategyImpl(_type=StrategyType.RollingUpdate, rollingUpdate=Some(rollingUpdate))
+    def unapply(strategy: Strategy): Option[(StrategyType.StrategyType, Option[RollingUpdate])] = 
+      Some(strategy._type,strategy.rollingUpdate)
+  }
+      
+  case class RollingUpdate(
+      maxUnavailable: IntOrString = Left(1),
+      maxSurge: IntOrString = Left(1))
+      
+  case class Status(
+      replicas: Int=0,
+      updatedReplicas: Int=0,
+      availableReplicas: Int = 0,
+      unavailableReplicas: Int = 0,
+      observedGeneration: Int = 0)
+}

--- a/client/src/main/scala/skuber/ext/package.scala
+++ b/client/src/main/scala/skuber/ext/package.scala
@@ -20,11 +20,6 @@ import skuber.api.client._
 package object ext {
   val extensionsAPIVersion = "extensions/v1beta1"
 
-  @deprecated("Use type `skuber.apps.Deployment` instead of `skuber.ext.Deployment", "Skuber 1.7")
-  type Deployment = skuber.apps.Deployment
-  @deprecated("Use type `skuber.apps.DeploymentList` instead of `skuber.ext.DeploymentList", "Skuber 1.7")
-  type DeploymentList = skuber.apps.DeploymentList
-
   @deprecated("Use type 'skuber.autoscaling.HorizontalPodAutoscaler' instead of 'skuber.ext.HorizontalPodAutoscaler'", "Skuber 1.7")
   type HorizontalPodAutoscaler = skuber.autoscaling.HorizontalPodAutoscaler
   @deprecated("Use type 'skuber.autoscaling.HorizontalPodAutoscalerList' instead of 'skuber.ext.HorizontalPodAutoscalerList'", "Skuber 1.7")

--- a/client/src/main/scala/skuber/json/ext/format/package.scala
+++ b/client/src/main/scala/skuber/json/ext/format/package.scala
@@ -18,6 +18,40 @@ import skuber.json.format._ // reuse some core formatters
 
 package object format {
 
+  // Deployment formatters
+  implicit val depStatusFmt: Format[Deployment.Status] = (
+    (JsPath \ "replicas").formatMaybeEmptyInt() and
+      (JsPath \ "updatedReplicas").formatMaybeEmptyInt() and
+      (JsPath \ "availableReplicas").formatMaybeEmptyInt() and
+      (JsPath \ "unavailableReplicas").formatMaybeEmptyInt() and
+      (JsPath \ "observedGeneration").formatMaybeEmptyInt()
+    )(Deployment.Status.apply _, unlift(Deployment.Status.unapply))
+
+
+  implicit val rollingUpdFmt: Format[Deployment.RollingUpdate] = (
+    (JsPath \ "maxUnavailable").formatMaybeEmptyIntOrString(Left(1)) and
+      (JsPath \ "maxSurge").formatMaybeEmptyIntOrString(Left(1))
+    )(Deployment.RollingUpdate.apply _, unlift(Deployment.RollingUpdate.unapply))
+
+  implicit val depStrategyFmt: Format[Deployment.Strategy] =  (
+    (JsPath \ "type").formatEnum(Deployment.StrategyType, Some(Deployment.StrategyType.RollingUpdate)) and
+      (JsPath \ "rollingUpdate").formatNullable[Deployment.RollingUpdate]
+    )(Deployment.Strategy.apply _, unlift(Deployment.Strategy.unapply))
+
+  implicit val depSpecFmt: Format[Deployment.Spec] = (
+    (JsPath \ "replicas").formatNullable[Int] and
+      (JsPath \ "selector").formatNullableLabelSelector and
+      (JsPath \ "template").formatNullable[Pod.Template.Spec] and
+      (JsPath \ "strategy").formatNullable[Deployment.Strategy] and
+      (JsPath \ "minReadySeconds").formatMaybeEmptyInt()
+    )(Deployment.Spec.apply _, unlift(Deployment.Spec.unapply))
+
+  implicit lazy val depFormat: Format[Deployment] = (
+    objFormat and
+      (JsPath \ "spec").formatNullable[Deployment.Spec] and
+      (JsPath \ "status").formatNullable[Deployment.Status]
+    ) (Deployment.apply _, unlift(Deployment.unapply))
+
   // DaemonSet formatters
 
   implicit val daemonSetRollingUpdateFmt: Format[DaemonSet.RollingUpdate] = Json.format[DaemonSet.RollingUpdate]

--- a/client/src/test/scala/skuber/ext/DeploymentSpec.scala
+++ b/client/src/test/scala/skuber/ext/DeploymentSpec.scala
@@ -1,11 +1,11 @@
-package skuber.apps
+package skuber.ext
 
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 
 import skuber.LabelSelector.dsl._
 import skuber._
-import skuber.json.apps.format._
+import skuber.json.ext.format._
 
 /**
  * @author David O'Riordan
@@ -24,7 +24,6 @@ class DeploymentSpec extends Specification {
     deployment.name mustEqual "example"
     deployment.status mustEqual None
   }
-  
   
   "A Deployment object can be written to Json and then read back again successfully" >> {
       val container=Container(name="example",image="example")
@@ -48,7 +47,7 @@ class DeploymentSpec extends Specification {
   "A Deployment object can be read directly from a JSON string" >> {
     val deplJsonStr = """
 {
-  "apiVersion": "apps/v1beta1",
+  "apiVersion": "extensions/v1beta1",
   "kind": "Deployment",
   "metadata": {
     "name": "nginx-deployment"

--- a/examples/src/main/scala/skuber/examples/deployment/DeploymentExamples.scala
+++ b/examples/src/main/scala/skuber/examples/deployment/DeploymentExamples.scala
@@ -1,8 +1,8 @@
 package skuber.examples.deployment
 
 import skuber._
-import skuber.apps.Deployment
-import skuber.json.apps.format._
+import skuber.ext.Deployment
+import skuber.json.ext.format._
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
Supports continued use of extensions group API deployment kind (via skuber.ext.Deployment class) for compatibility with pre 1.6 Kubernetes - clients targetting later versions can/should use skuber.apps.Deployment instead 