### PR TITLE
resolves #78: added Pod.Spec.Affinity support with test

### DIFF
--- a/client/src/main/scala/skuber/annotation/NodeAffinity.scala
+++ b/client/src/main/scala/skuber/annotation/NodeAffinity.scala
@@ -4,6 +4,9 @@ import skuber.annotation.NodeAffinity.{MatchExpressions, NodeSelectorTerms}
 
 /**
   * Created by Cory Klein on 2/22/17.
+  *
+  * 2017-10-05: per https://github.com/kubernetes/kubernetes/issues/44339, node affinity via annotation is not supported by default in
+  * Kubernetes 1.6 or later. It should be set directly in the Pod.Spec (see PodFormatSpec for an example)
   */
 case class NodeAffinity(
                     requiredDuringSchedulingIgnoredDuringExecution: Option[RequiredDuringSchedulingIgnoredDuringExecution],

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -491,7 +491,34 @@ package object format {
       (JsPath \ "spec").formatNullable[Pod.Spec] and
       (JsPath \ "status").formatNullable[Pod.Status]
     ) (Pod.apply _, unlift(Pod.unapply))  
-    
+
+
+  implicit val nodeAffinityOperatorFormat: Format[Pod.Affinity.Operator.Operator] = Format(enumReads(Pod.Affinity.Operator), enumWrites)
+
+  implicit val matchExpressionFormat: Format[Pod.Affinity.MatchExpression] = (
+    (JsPath \ "key").formatMaybeEmptyString() and
+      (JsPath \ "operator").formatEnum(Pod.Affinity.Operator) and
+      (JsPath \ "values").formatMaybeEmptyList[String]
+    )(Pod.Affinity.MatchExpression.apply _, unlift(Pod.Affinity.MatchExpression.unapply))
+
+  implicit val nodeSelectorTermFormat: Format[Pod.Affinity.NodeSelectorTerm] = (
+    (JsPath \ "matchExpressions").format[Pod.Affinity.MatchExpressions].inmap(matchExpressions => Pod.Affinity.NodeSelectorTerm(matchExpressions), (nst: Pod.Affinity.NodeSelectorTerm) => nst.matchExpressions)
+    )
+
+  implicit val requiredDuringSchedulingIgnoredDuringExecutionFormat: Format[Pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution] = (
+    (JsPath \ "nodeSelectorTerms").format[Pod.Affinity.NodeSelectorTerms].inmap(
+      nodeSelectorTerms => Pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms),
+      (rdside: Pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution) => rdside.nodeSelectorTerms)
+    )
+
+  implicit lazy val preferredSchedulingTermFormat : Format[Pod.Affinity.NodeAffinity.PreferredSchedulingTerm] = Json.format[Pod.Affinity.NodeAffinity.PreferredSchedulingTerm]
+
+  implicit lazy val nodeAffinityFormat : Format[Pod.Affinity.NodeAffinity] = (
+    (JsPath \ "requiredDuringSchedulingIgnoredDuringExecution").formatNullable[Pod.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution] and
+      (JsPath \ "preferredDuringSchedulingIgnoredDuringExecution").formatMaybeEmptyList[Pod.Affinity.NodeAffinity.PreferredSchedulingTerm]
+  )(Pod.Affinity.NodeAffinity.apply _, unlift(Pod.Affinity.NodeAffinity.unapply))
+
+  implicit lazy val affinityFormat : Format[Pod.Affinity] = Json.format[Pod.Affinity]
   
   implicit val podSpecFormat: Format[Pod.Spec] = (
       (JsPath \ "containers").format[List[Container]] and
@@ -504,7 +531,8 @@ package object format {
       (JsPath \ "serviceAccountName").formatMaybeEmptyString() and
       (JsPath \ "nodeName").formatMaybeEmptyString() and
       (JsPath \ "hostNetwork").formatMaybeEmptyBoolean() and
-      (JsPath \ "imagePullSecrets").formatMaybeEmptyList[LocalObjectReference]
+      (JsPath \ "imagePullSecrets").formatMaybeEmptyList[LocalObjectReference] and
+      (JsPath \ "affinity").formatNullable[Pod.Affinity]
     )(Pod.Spec.apply _, unlift(Pod.Spec.unapply))
     
   implicit val podTemplSpecFormat: Format[Pod.Template.Spec] = Json.format[Pod.Template.Spec]

--- a/client/src/test/resources/exampleAffinity.json
+++ b/client/src/test/resources/exampleAffinity.json
@@ -1,0 +1,36 @@
+{
+  "nodeAffinity": {
+    "requiredDuringSchedulingIgnoredDuringExecution": {
+      "nodeSelectorTerms": [
+        {
+          "matchExpressions": [
+            {
+              "key": "kubernetes.io/e2e-az-name",
+              "operator": "In",
+              "values": [
+                "e2e-az1",
+                "e2e-az2"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "preferredDuringSchedulingIgnoredDuringExecution": [
+      {
+        "weight": 1,
+        "preference": {
+          "matchExpressions": [
+            {
+              "key": "another-node-label-key",
+              "operator": "In",
+              "values": [
+                "another-node-label-value"
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/client/src/test/resources/exampleAffinityNoPreferences.json
+++ b/client/src/test/resources/exampleAffinityNoPreferences.json
@@ -1,0 +1,20 @@
+{
+  "nodeAffinity": {
+    "requiredDuringSchedulingIgnoredDuringExecution": {
+      "nodeSelectorTerms": [
+        {
+          "matchExpressions": [
+            {
+              "key": "kubernetes.io/e2e-az-name",
+              "operator": "In",
+              "values": [
+                "e2e-az1",
+                "e2e-az2"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/client/src/test/resources/exampleAffinityNoRequirements.json
+++ b/client/src/test/resources/exampleAffinityNoRequirements.json
@@ -1,0 +1,20 @@
+{
+  "nodeAffinity": {
+    "preferredDuringSchedulingIgnoredDuringExecution": [
+      {
+        "weight": 1,
+        "preference": {
+          "matchExpressions": [
+            {
+              "key": "another-node-label-key",
+              "operator": "In",
+              "values": [
+                "another-node-label-value"
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/client/src/test/resources/examplePodWithNodeAffinity.json
+++ b/client/src/test/resources/examplePodWithNodeAffinity.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "with-node-affinity"
+  },
+  "spec": {
+    "affinity": {
+      "nodeAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "nodeSelectorTerms": [
+            {
+              "matchExpressions": [
+                {
+                  "key": "kubernetes.io/e2e-az-name",
+                  "operator": "In",
+                  "values": [
+                    "e2e-az1",
+                    "e2e-az2"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "preferredDuringSchedulingIgnoredDuringExecution": [
+          {
+            "weight": 1,
+            "preference": {
+              "matchExpressions": [
+                {
+                  "key": "another-node-label-key",
+                  "operator": "In",
+                  "values": [
+                    "another-node-label-value"
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "containers": [
+      {
+        "name": "with-node-affinity",
+        "image": "gcr.io/google_containers/pause:2.0"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
i had hoped to use as much code as possible from the existing `skuber.annotation.NodeAffinity` work by @coryfklein , but the syntax for the placement preferences has changed. 
So, this new stuff (under `Pod.Affinity`) is entirely separate.

let me know how it looks. i'm already using it from a self-published library in my own project, but i'm open to changing it if you don't like the structure.