### PR TITLE
added cross-compile support for 2.11 and 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ developers in ThisBuild := List(Developer(id="doriordan", name="David ORiordan",
 
 lazy val commonSettings = Seq(
   organization := "io.skuber",
-  scalaVersion := "2.12.3",
+  crossScalaVersions := Seq("2.11.12", "2.12.4"),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value)

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -98,7 +98,7 @@ package object client {
      logResponseFullObjectResource: Boolean=loggingEnabled("response.object.full", false), // outputs full received object resource, if available
      logResponseListSize: Boolean=loggingEnabled("response.list.size", false), // logs size of any returned list resource
      logResponseListNames: Boolean=loggingEnabled("response.list.names", false), // logs list of names of items in any returned list resource
-     logResponseFullListResource: Boolean= loggingEnabled("response.list.full", false), // outputs full contained object resources in list resources
+     logResponseFullListResource: Boolean= loggingEnabled("response.list.full", false) // outputs full contained object resources in list resources
    )
 
    trait LoggingContext {


### PR DESCRIPTION
Nice work on v2 of the library. 

I need to use it on both 2.11 an 2.12 for the time being since my entire code base has not been moved to 2.12. 

Running '+ test' has both versions passing all tests.

Would be willing to support 2.11 as well for a while in the v2.x versions on the library? 