### PR TITLE
- Added a missing implicit for RoleBindingList

### DIFF
--- a/client/src/main/scala/skuber/rbac/RoleBinding.scala
+++ b/client/src/main/scala/skuber/rbac/RoleBinding.scala
@@ -15,17 +15,19 @@ case class RoleBinding(
 ) extends ObjectResource
 
 object RoleBinding {
-  implicit val roleDef = new ResourceDefinition[RoleBinding] {
-    def spec = NonCoreResourceSpecification (
-      group=Some("rbac.authorization.k8s.io"),
-      version="v1beta1",
-      scope = Scope.Namespaced,
-      names=Names(
-        plural = "rolebindings",
-        singular = "rolebinding",
-        kind = "RoleBinding",
-        shortNames = Nil
-      )
+
+  def specification = NonCoreResourceSpecification (
+    group=Some("rbac.authorization.k8s.io"),
+    version="v1beta1",
+    scope = Scope.Namespaced,
+    names=Names(
+      plural = "rolebindings",
+      singular = "rolebinding",
+      kind = "RoleBinding",
+      shortNames = Nil
     )
-  }
+  )
+
+  implicit val roleDef = new ResourceDefinition[RoleBinding] { def spec = specification }
+  implicit val roleListDef = new ResourceDefinition[RoleBindingList] { def spec = specification }
 }


### PR DESCRIPTION
This is a fix for issue #95 , it adds an implicit for RoleBindingList that is needed when doing a query:

`k8s.listInNamespace[RoleBindingList](...)`