### PR TITLE
Use Akka Logging instead of slf4j directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,6 @@ val specs2 = "org.specs2" %% "specs2-core" % "3.9.5"
 val snakeYaml =  "org.yaml" % "snakeyaml" % "1.16"
 val commonsIO = "commons-io" % "commons-io" % "2.5"
 val commonsCodec = "commons-codec" % "commons-codec" % "1.10"
-val sl4j = "org.slf4j" % "slf4j-api" % "1.7.25"
 
 // the client API request/response handing uses Akka Http 
 // This also brings in the transitive dependencies on Akka actors and streams
@@ -55,7 +54,7 @@ lazy val commonSettings = Seq(
 
 lazy val skuberSettings = Seq(
   name := "skuber",
-  libraryDependencies ++= Seq(akkaHttp, playJson, snakeYaml, commonsIO, commonsCodec, sl4j, scalaCheck % Test,specs2 % Test).
+  libraryDependencies ++= Seq(akkaHttp, playJson, snakeYaml, commonsIO, commonsCodec, scalaCheck % Test,specs2 % Test).
 				map(_.exclude("commons-logging","commons-logging"))
 )
 

--- a/client/src/main/scala/skuber/api/Watch.scala
+++ b/client/src/main/scala/skuber/api/Watch.scala
@@ -14,7 +14,6 @@ import play.api.libs.json.{Format, JsError, JsSuccess, Json}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
-import org.slf4j.LoggerFactory
 
 import scala.language.postfixOps
 
@@ -25,8 +24,6 @@ import scala.language.postfixOps
  */
 object Watch {
   
-  val log = LoggerFactory.getLogger("skuber.api")
-
   /**
     * Get a source of events on a specific Kubernetes resource
     * @param context the applicable request context

--- a/client/src/main/scala/skuber/json/PlayJsonSupportForAkkaHttp.scala
+++ b/client/src/main/scala/skuber/json/PlayJsonSupportForAkkaHttp.scala
@@ -32,9 +32,6 @@ import akka.util.ByteString
 import play.api.libs.json.{ JsError, JsValue, Json, Reads, Writes }
 import scala.collection.immutable.Seq
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope *play-json* protocol.
   */
@@ -45,7 +42,6 @@ object PlayJsonSupportForAkkaHttp extends PlayJsonSupportForAkkaHttp {
       JsError.toJson(error).toString()
   }
 
-  override val log: Logger = LoggerFactory.getLogger("skuber.api")
 }
 
 /**
@@ -53,8 +49,6 @@ object PlayJsonSupportForAkkaHttp extends PlayJsonSupportForAkkaHttp {
   */
 trait PlayJsonSupportForAkkaHttp {
   import PlayJsonSupportForAkkaHttp._
-
-   val log: Logger
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
     List(`application/json`)
@@ -85,19 +79,10 @@ trait PlayJsonSupportForAkkaHttp {
             )
           }
     jsonStringUnmarshaller.map { data =>
-      if (log.isDebugEnabled) {
-        log.debug(s"[Skuber reading: $data]")
-      }
       read(Json.parse(data))
     }
   }
 
-  val logMarshalled: String => String = { marshalled =>
-    if(log.isDebugEnabled) {
-      log.debug(s"[Skuber writing; $marshalled")
-    }
-    marshalled
-  }
   /**
     * `A` => HTTP entity
     *
@@ -108,5 +93,5 @@ trait PlayJsonSupportForAkkaHttp {
     implicit writes: Writes[A],
     printer: JsValue => String = Json.prettyPrint
   ): ToEntityMarshaller[A] =
-    jsonStringMarshaller.compose(logMarshalled).compose(printer).compose(writes.writes)
+    jsonStringMarshaller.compose(printer).compose(writes.writes)
 }

--- a/examples/application.conf
+++ b/examples/application.conf
@@ -1,5 +1,7 @@
 akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
 #  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   actor {
     debug {
 #      receive = on


### PR DESCRIPTION
Use asynchronous `Logging` produced by Akka instead of using slf4j directly. It makes logging backend swappable and prevent performance impact as recommended in [the official document](https://doc.akka.io/docs/akka/current/logging.html).