### PR TITLE
Stateful set scaling

### DIFF
--- a/client/src/main/scala/skuber/ReplicationController.scala
+++ b/client/src/main/scala/skuber/ReplicationController.scala
@@ -56,6 +56,8 @@ object ReplicationController {
   implicit val rcDef = new ResourceDefinition[ReplicationController] { def spec=specification }
   implicit val rcListDef = new ResourceDefinition[ReplicationControllerList] { def spec=specification }
 
+  implicit val scSpec=new Scale.SubresourceSpec[ReplicationController] { override def apiVersion = "autoscaling/v1" }
+
   def apply(name: String) : ReplicationController = ReplicationController(metadata=ObjectMeta(name=name))
   def apply(name: String, spec: ReplicationController.Spec) : ReplicationController =
     ReplicationController(metadata=ObjectMeta(name=name), spec = Some(spec))

--- a/client/src/main/scala/skuber/Scale.scala
+++ b/client/src/main/scala/skuber/Scale.scala
@@ -26,6 +26,7 @@ object Scale {
   object Spec {
     implicit val scaleSpecFormat: Format[Scale.Spec] = Json.format[Scale.Spec]
   }
+
   case class Status(
     replicas: Int = 0,
     selector: Option[String] = None,

--- a/client/src/main/scala/skuber/Scale.scala
+++ b/client/src/main/scala/skuber/Scale.scala
@@ -7,16 +7,15 @@ import skuber.json.format.{maybeEmptyFormatMethods,objectMetaFormat}
 
 /**
  * @author David O'Riordan
+ *  Scale subresource
  */
 case class Scale(
     val kind: String = "Scale",
     val apiVersion: String,
     val metadata: ObjectMeta,
     spec: Scale.Spec = Scale.Spec(),
-    status: Option[Scale.Status] = None) extends ObjectResource {
-  
-  def withResourceVersion(version: String) = this.copy(metadata = metadata.copy(resourceVersion=version))
-
+    status: Option[Scale.Status] = None) extends ObjectResource
+{
   def withReplicas(count: Int) = this.copy(spec=Scale.Spec(count))
 }
     
@@ -35,14 +34,19 @@ object Scale {
 
   object Status {
     implicit val scaleStatusFormat: Format[Scale.Status] = (
-        (JsPath \ "replicas").formatMaybeEmptyInt() and
-        (JsPath \ "selector").formatNullable[String] and
-        (JsPath \ "targetSelector").formatNullable[String]
-        )(Scale.Status.apply _, unlift(Scale.Status.unapply))
+      (JsPath \ "replicas").formatMaybeEmptyInt() and
+      (JsPath \ "selector").formatNullable[String] and
+      (JsPath \ "targetSelector").formatNullable[String]
+    )(Scale.Status.apply _, unlift(Scale.Status.unapply))
   }
 
   implicit val scaleSpecFormat: Format[Scale.Spec] = Json.format[Scale.Spec]
   implicit val scaleFormat: Format[Scale] = Json.format[Scale]
 
-
+  // Any object resource type [O <: ObjectResource] that supports a Scale subresource must provide an implicit value of
+  // SubresourceSpec type to enable the client API method `scale` to be used on such resources
+  // Kubernetes supports Scale subresources on ReplicationController/ReplicaSet/Deployment/StatefulSet types
+  trait SubresourceSpec[O <: ObjectResource] {
+    def apiVersion: String // the API version to be set on any Scale subresource of the specific resource type O
+  }
 }    

--- a/client/src/main/scala/skuber/Service.scala
+++ b/client/src/main/scala/skuber/Service.scala
@@ -37,7 +37,8 @@ case class Service(
     else
       updated
   }
-    
+
+  def isHeadless = this.copy(spec=Some(copySpec.copy(clusterIP = "None")))
   def withClusterIP(ip: String) = this.copy(spec = Some(copySpec.copy(clusterIP = ip)))
   def withType(_type: Service.Type.Value) = this.copy(spec = Some(copySpec.copy(_type = _type)))
   def withLoadBalancerType = withType(Service.Type.LoadBalancer)

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -461,8 +461,8 @@ package object client {
      }
 
      // Operations on scale subresource
-     // Only exists for certain resource kinds like RC, RS, Deployment, StatefulSet, so these are marked out
-     // by implementing the Scale.SubresourceSpec trait implicitly
+     // Scale subresource Only exists for certain resource types like RC, RS, Deployment, StatefulSet so only those types
+     // define an implicit Scale.SubresourceSpec, which is required to be passed to these methods.
 
      def getScale[O <: ObjectResource](objName: String)(
        implicit rd: ResourceDefinition[O], sc: Scale.SubresourceSpec[O], lc: LoggingContext=RequestLoggingContext()) : Future[Scale] =

--- a/client/src/main/scala/skuber/apps/Deployment.scala
+++ b/client/src/main/scala/skuber/apps/Deployment.scala
@@ -71,7 +71,7 @@ object Deployment {
   )
   implicit val deployDef = new ResourceDefinition[Deployment] { def spec=specification }
   implicit val deployListDef =  new ResourceDefinition[DeploymentList] { def spec=specification }
-  implicit val scDef = new Scale.SubresourceSpec[Deployment] { override def apiVersion = "apps/v1beta2"}
+  implicit val scDef = new Scale.SubresourceSpec[Deployment] { override def apiVersion = "apps/v1beta1"}
 
   def apply(name: String) = new Deployment(metadata=ObjectMeta(name=name))
   

--- a/client/src/main/scala/skuber/apps/Deployment.scala
+++ b/client/src/main/scala/skuber/apps/Deployment.scala
@@ -13,8 +13,8 @@ case class Deployment(
     val metadata: ObjectMeta = ObjectMeta(),
     val spec:  Option[Deployment.Spec] = None,
     val status: Option[Deployment.Status] = None)
-      extends ObjectResource {
-  
+      extends ObjectResource
+{
   def withResourceVersion(version: String) = this.copy(metadata = metadata.copy(resourceVersion=version))
 
   lazy val copySpec = this.spec.getOrElse(new Deployment.Spec)
@@ -71,6 +71,7 @@ object Deployment {
   )
   implicit val deployDef = new ResourceDefinition[Deployment] { def spec=specification }
   implicit val deployListDef =  new ResourceDefinition[DeploymentList] { def spec=specification }
+  implicit val scDef = new Scale.SubresourceSpec[Deployment] { override def apiVersion = "apps/v1beta2"}
 
   def apply(name: String) = new Deployment(metadata=ObjectMeta(name=name))
   

--- a/client/src/main/scala/skuber/apps/StatefulSet.scala
+++ b/client/src/main/scala/skuber/apps/StatefulSet.scala
@@ -1,26 +1,29 @@
 package skuber.apps
 
 import skuber.ResourceSpecification.{Names, Scope}
-import skuber.ext.extensionsAPIVersion
-import skuber.{LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, PersistentVolumeClaim, Pod, ResourceDefinition, Timestamp}
+import skuber.{LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, PersistentVolumeClaim, Pod, ResourceDefinition, Scale, Timestamp}
 
 /**
   * Created by hollinwilkins on 4/5/17.
   */
 case class StatefulSet(override val kind: String ="StatefulSet",
-                       override val apiVersion: String = extensionsAPIVersion,
+                       override val apiVersion: String = appsAPIVersion,
                        metadata: ObjectMeta,
                        spec:  Option[StatefulSet.Spec] = None,
-                       status:  Option[StatefulSet.Status] = None) extends ObjectResource {
+                       status:  Option[StatefulSet.Status] = None) extends ObjectResource
+{
   def withResourceVersion(version: String) = this.copy(metadata = metadata.copy(resourceVersion=version))
 
   lazy val copySpec = this.spec.getOrElse(new StatefulSet.Spec(template = Pod.Template.Spec()))
+  private val rollingUpdateStrategy = StatefulSet.UpdateStrategy(`type`=StatefulSet.UpdateStrategyType.RollingUpdate, None)
+  private def rollingUpdateStrategy(partition: Int)=
+    StatefulSet.UpdateStrategy(`type`=StatefulSet.UpdateStrategyType.RollingUpdate,Some(StatefulSet.RollingUpdateStrategy(partition)))
 
   def withReplicas(count: Int) = this.copy(spec=Some(copySpec.copy(replicas=Some(count))))
   def withServiceName(serviceName: String) = this.copy(spec=Some(copySpec.copy(serviceName=Some(serviceName))))
   def withTemplate(template: Pod.Template.Spec) = this.copy(spec=Some(copySpec.copy(template=template)))
   def withLabelSelector(sel: LabelSelector) = this.copy(spec=Some(copySpec.copy(selector=Some(sel))))
-
+  def withRollingUpdateStrategyPartition(partition:Int) = this.copy(spec=Some(copySpec.copy(updateStrategy = Some(rollingUpdateStrategy(partition)))))
   def withVolumeClaimTemplate(claim: PersistentVolumeClaim) = {
     val spec = copySpec.withVolumeClaimTemplate(claim)
     this.copy(spec=Some(spec))
@@ -42,9 +45,9 @@ object StatefulSet {
   )
   implicit val stsDef = new ResourceDefinition[StatefulSet] { def spec=specification }
   implicit val stsListDef = new ResourceDefinition[StatefulSetList] { def spec=specification }
+  implicit val scDef = new Scale.SubresourceSpec[StatefulSet] { override def apiVersion = "apps/v1beta1"}
 
-  def apply(name: String): StatefulSet =
-    StatefulSet(metadata=ObjectMeta(name=name))
+  def apply(name: String): StatefulSet = StatefulSet(metadata=ObjectMeta(name=name))
 
   object PodManagementPolicyType extends Enumeration {
     type PodManagementPolicyType = Value

--- a/client/src/main/scala/skuber/apps/v1beta1/StatefulSet.scala
+++ b/client/src/main/scala/skuber/apps/v1beta1/StatefulSet.scala
@@ -1,4 +1,4 @@
-package skuber.apps
+package skuber.apps.v1beta1
 
 import skuber.ResourceSpecification.{Names, Scope}
 import skuber.{LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, PersistentVolumeClaim, Pod, ResourceDefinition, Scale, Timestamp}

--- a/client/src/main/scala/skuber/apps/v1beta1/StatefulSet.scala
+++ b/client/src/main/scala/skuber/apps/v1beta1/StatefulSet.scala
@@ -5,11 +5,9 @@ import skuber.{LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectRe
 
 /**
   * Created by hollinwilkins on 4/5/17.
-  * The api version of this StatefulSet type is v1beta2, which is for use with k8s 1.8+.
-  * For earlier versions of k8s, use skuber.apps.v1beta1.StatefulSet
   */
 case class StatefulSet(override val kind: String ="StatefulSet",
-                       override val apiVersion: String = "apps/v1beta2", // correct at k8s 1.8
+                       override val apiVersion: String = "apps/v1beta1", // correct at k8s 1.7
                        metadata: ObjectMeta,
                        spec:  Option[StatefulSet.Spec] = None,
                        status:  Option[StatefulSet.Status] = None) extends ObjectResource
@@ -36,7 +34,7 @@ object StatefulSet {
 
   val specification=NonCoreResourceSpecification (
     group=Some("apps"),
-    version="v1beta2", // version as at k8s v1.8
+    version="v1beta1", // version as at k8s v1.7
     scope = Scope.Namespaced,
     names=Names(
       plural = "statefulsets",
@@ -47,7 +45,6 @@ object StatefulSet {
   )
   implicit val stsDef = new ResourceDefinition[StatefulSet] { def spec=specification }
   implicit val stsListDef = new ResourceDefinition[StatefulSetList] { def spec=specification }
-  implicit val scDef = new Scale.SubresourceSpec[StatefulSet] { override def apiVersion = "apps/v1beta2"}
 
   def apply(name: String): StatefulSet = StatefulSet(metadata=ObjectMeta(name=name))
 

--- a/client/src/main/scala/skuber/apps/v1beta1/package.scala
+++ b/client/src/main/scala/skuber/apps/v1beta1/package.scala
@@ -1,0 +1,10 @@
+package skuber.apps
+
+import skuber.ListResource
+
+package object v1beta1 {
+    val appsAPIVersion = "apps/v1beta1"
+
+    type StatefulSetList = ListResource[skuber.apps.v1beta1.StatefulSet]
+
+}

--- a/client/src/main/scala/skuber/autoscaling/HorizontalPodAutoscaler.scala
+++ b/client/src/main/scala/skuber/autoscaling/HorizontalPodAutoscaler.scala
@@ -8,6 +8,11 @@ import skuber.json.format.objectMetaFormat
 
 /**
  * @author David O'Riordan
+ * Note: this supports the original "autoscaling/v1" version of HPAS , which has CPU utilisation
+ * as a target metric.
+ * Support for the newer "v2beta1" version , introduced in k8s v1.6 and which supports memory
+ * and custom metrics, is not yet done
+ *
  */
 case class HorizontalPodAutoscaler(
   	val kind: String ="HorizontalPodAutoscaler",

--- a/client/src/main/scala/skuber/ext/Deployment.scala
+++ b/client/src/main/scala/skuber/ext/Deployment.scala
@@ -77,7 +77,7 @@ object Deployment {
 
   implicit val deployDef: ResourceDefinition[Deployment] = new ResourceDefinition[Deployment] { def spec=specification }
   implicit val deployListDef: ResourceDefinition[ListResource[Deployment]] =  new ResourceDefinition[ListResource[Deployment]] { def spec=specification }
-  implicit val scDef = new Scale.SubresourceSpec[Deployment] { override def apiVersion = "apps/v1beta2" }
+  implicit val scDef = new Scale.SubresourceSpec[Deployment] { override def apiVersion = "apps/v1beta1" }
 
   def apply(name: String) = new Deployment(metadata=ObjectMeta(name=name))
   

--- a/client/src/main/scala/skuber/ext/Deployment.scala
+++ b/client/src/main/scala/skuber/ext/Deployment.scala
@@ -4,6 +4,7 @@ package skuber.ext
  * @author David O'Riordan
  */
 
+import skuber.Scale
 import skuber.ResourceSpecification.{Names, Scope}
 import skuber.{Container, IntOrString, LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, Pod, ListResource, ResourceDefinition}
 
@@ -73,8 +74,10 @@ object Deployment {
       shortNames = List("deploy")
     )
   )
+
   implicit val deployDef: ResourceDefinition[Deployment] = new ResourceDefinition[Deployment] { def spec=specification }
   implicit val deployListDef: ResourceDefinition[ListResource[Deployment]] =  new ResourceDefinition[ListResource[Deployment]] { def spec=specification }
+  implicit val scDef = new Scale.SubresourceSpec[Deployment] { override def apiVersion = "apps/v1beta2" }
 
   def apply(name: String) = new Deployment(metadata=ObjectMeta(name=name))
   

--- a/client/src/main/scala/skuber/ext/ReplicaSet.scala
+++ b/client/src/main/scala/skuber/ext/ReplicaSet.scala
@@ -76,6 +76,7 @@ object ReplicaSet {
   )
   implicit val rsDef = new ResourceDefinition[ReplicaSet] { def spec=specification }
   implicit val rsListDef = new ResourceDefinition[ReplicaSetList] { def spec=specification }
+  implicit val scDef = new Scale.SubresourceSpec[ReplicaSet] { override def apiVersion: String = "extensions/v1beta1"}
 
   def apply(name: String) : ReplicaSet = ReplicaSet(metadata=ObjectMeta(name=name))
   def apply(name: String, spec: ReplicaSet.Spec) : ReplicaSet =

--- a/client/src/main/scala/skuber/ext/package.scala
+++ b/client/src/main/scala/skuber/ext/package.scala
@@ -35,102 +35,75 @@ package object ext {
   type IngressList = ListResource[Ingress]
   type DeploymentList = ListResource[Deployment]
 
-  // Extensions Group API methods - for the moment this includes commands to get or change the scale on
-  // a RC or Deployment Scale subresource, returning a Scale object with the updated spec and status.
-  // (see [[http://kubernetes.io/v1.1/docs/design/horizontal-pod-autoscaler.html here]] for details about the
-  // Scale subresource type). 
-  // The standard K8SRequestContext RESTful API methods will work with Extensions API top-level 
-  // resource types such as HorizontalPodAutoscaler and Deployment, so no additional methods are 
-  // required here for creating, updating etc. these types.
-  //
-  // NOTE: in a future release these scale methods are likely to be moved or modified
+  // Extensions Group API methods - this just holds some deprecated methods for accessing scale subresources (update/get scale)
+  // that are imported implicitly with this package import (i.e. `import skuber.ext._`). In the future this class will be removed,
+  // so clients should use e.g. `k8s.scale[T](name,count)` instead where `T' is a supported resource type such as Deployment or StatefulSet.
 
   class ExtensionsGroupAPI(val context: K8SRequestContext)
   {
-    private[this] def getScale[O <: ObjectResource](objName: String)(
-      implicit rd: ResourceDefinition[O], lc: LoggingContext) : Future[Scale] =
-    {
-      val req = context.buildRequest(HttpMethods.GET, rd, Some(objName+ "/scale"))
-      context.makeRequestReturningObjectResource[Scale](req)
-    }
-
-    private[this] def scale[O <: ObjectResource](
-      apiVersion: String,
-      objName: String,
-      count: Int)(implicit rd: ResourceDefinition[O], lc:LoggingContext): Future[Scale] =
-    {
-      val scale = Scale(
-        apiVersion = apiVersion,
-        metadata = ObjectMeta(name = objName, namespace = context.namespaceName),
-        spec = Scale.Spec(replicas = count)
-      )
-      implicit val dispatcher=context.actorSystem.dispatcher
-      val marshal = Marshal(scale)
-      for {
-        requestEntity <- marshal.to[RequestEntity]
-        httpRequest = context
-              .buildRequest(HttpMethods.PUT, rd, Some(s"${objName}/scale"))
-              .withEntity(requestEntity.withContentType(MediaTypes.`application/json`))
-        scaledResource <- context.makeRequestReturningObjectResource[Scale](httpRequest)
-      } yield scaledResource
-    }
-
     /*
      * Modify the specified replica count for a replication controller, returning a Future with its
      * updated Scale subresource
      */
+    @deprecated(message="Use method scale[ReplicationController](name,count) instead")
     def scale(rc: ReplicationController, count: Int): Future[Scale] =
       scaleReplicationController(rc.name, count)
      
     /*
      * Modify the specified replica count for a Deployment, returning a Future with its
      * updated Scale subresource
-     */  
+     */
+    @deprecated(message="Use method scale[Deployment](name,count) instead")
     def scale(de: skuber.apps.Deployment, count: Int): Future[Scale] =
       scaleDeployment(de.name,  count)
-      
+
     /*
      * Modify the specified replica count for a named replication controller, returning a Future with its
      * updated Scale subresource
      */
+    @deprecated(message="Use method scale[ReplicationController](name,count) instead")
     def scaleReplicationController(name: String, count: Int)(implicit lc:LoggingContext=RequestLoggingContext()): Future[Scale] =
-      scale[ReplicationController]("autoscaling/v1", name, count)
+      context.scale[ReplicationController](name, count)
 
     /*
     * Modify the specified replica count for a named replica set, returning a Future with its
     * updated Scale subresource
     */
+    @deprecated(message="Use method scale[ReplicaSet(name,count) instead")
     def scaleReplicaSet(name: String, count: Int)(implicit lc:LoggingContext=RequestLoggingContext()): Future[Scale] =
-      scale[ReplicaSet]("extensions/v1beta1", name, count)
+      context.scale[ReplicaSet](name, count)
 
     /*
      * Modify the specified replica count for a named Deployment, returning a Future with its
      * updated Scale subresource
-     */     
+     */
+    @deprecated(message="Use method scale[Deployment](name,count) instead")
     def scaleDeployment(name: String, count: Int)(implicit lc:LoggingContext=RequestLoggingContext()): Future[Scale] =
-      scale[skuber.apps.Deployment]("apps/v1beta1", name, count)
-      
+      context.scale[Deployment](name, count)
+
     /*
      * Fetch the Scale subresource of a named Deployment
      * @returns a future containing the retrieved Scale subresource
      */
-    def getDeploymentScale(objName: String)(implicit lc:LoggingContext=RequestLoggingContext()) = getScale[skuber.apps.Deployment](objName)
+    @deprecated(message="Use method getScale[Deployment](name) instead")
+    def getDeploymentScale(objName: String)(implicit lc:LoggingContext=RequestLoggingContext()) = context.getScale[skuber.apps.Deployment](objName)
     
     /*
      * Fetch the Scale subresource of a named Replication Controller
      * @returns a future containing the retrieved Scale subresource
      */
-    def getReplicationControllerScale(objName: String)(implicit lc:LoggingContext=RequestLoggingContext()) = getScale[ReplicationController](objName)
+    @deprecated(message="Use method getScale[ReplicationController](name) instead")
+    def getReplicationControllerScale(objName: String)(implicit lc:LoggingContext=RequestLoggingContext()) = context.getScale[ReplicationController](objName)
 
     /*
      * Fetch the Scale subresource of a named Replication Controller
      * @returns a future containing the retrieved Scale subresource
      */
-    def getReplicaSetScale(objName: String)(implicit lc:LoggingContext=RequestLoggingContext()) = getScale[ReplicaSet](objName)
-
+    @deprecated(message="Use method getScale[ReplicaSet](name) instead")
+    def getReplicaSetScale(objName: String)(implicit lc:LoggingContext=RequestLoggingContext()) = context.getScale[ReplicaSet](objName)
   }
   
-  // this implicit conversions makes the ExtensionsAPI methods available on a 
+  // this implicit conversions makes the (deprecated) ExtensionsAPI methods available on a
   // standard Skuber request context object
   implicit def k8sCtxToExtAPI(ctx: K8SRequestContext) = new ExtensionsGroupAPI(ctx)
 }

--- a/client/src/test/scala/skuber/apps/StatefulSetSpec.scala
+++ b/client/src/test/scala/skuber/apps/StatefulSetSpec.scala
@@ -28,7 +28,6 @@ class StatefulSetSpec extends Specification {
     stateSet.status mustEqual None
   }
 
-
   "A StatefulSet object can be written to Json and then read back again successfully" >> {
     val container=Container(name="example",image="example")
     val template=Pod.Template.Spec.named("example").addContainer(container)

--- a/client/src/test/scala/skuber/apps/StatefulSetSpec.scala
+++ b/client/src/test/scala/skuber/apps/StatefulSetSpec.scala
@@ -74,7 +74,7 @@ class StatefulSetSpec extends Specification {
     stateSet.spec.get.selector.get.requirements.find(r => (r.key == "env")) mustEqual Some("env" isNotIn List("dev"))
     stateSet.spec.get.selector.get.requirements.find(r => (r.key == "domain")) mustEqual Some("domain" is "www.example.com")
 
-    // write and read back in again, should be unchanged 
+    // write and read back in again, should be unchanged
     val json = Json.toJson(stateSet)
     val readSS = Json.fromJson[StatefulSet](json).get
     readSS mustEqual stateSet

--- a/examples/src/main/scala/skuber/examples/scale/ScaleExamples.scala
+++ b/examples/src/main/scala/skuber/examples/scale/ScaleExamples.scala
@@ -5,22 +5,39 @@ import akka.stream.ActorMaterializer
 
 import skuber._
 import skuber.autoscaling.HorizontalPodAutoscaler
-import skuber.json.format._
-import skuber.ext._
+import skuber.json.apps.format._
+import skuber.apps._
 
 /**
  * @author David O'Riordan
  * 
- * Some simple examples of using the extensions API to scale up and down a Replication Controller
+ * Some simple examples of using the extensions API to scale up and down a StatefulSet
  * or Deployment resource.
+  * Note: StatefulSet scaling via this method is only supported by Kubernetes v1.8 and later
  */
 object ScaleExamples extends App {
  
-  def scaleNginxController = {
-    
-    val nginxSelector  = Map("example" -> "scale")
+  def scaleNginx = {
+
     val nginxContainer = Container("nginx",image="nginx").exposePort(80)
-    val nginxController= ReplicationController("nginx-scale-example",nginxContainer,nginxSelector).withReplicas(5)
+    val nginxBaseSpec = Pod.Template.Spec().addContainer(nginxContainer)
+
+    val nginxDeploymentLabels=Map("scale-example-type" -> "deployment")
+    val nginxDeploymentSel=LabelSelector(LabelSelector.InRequirement("scale-example-type",List("deployment")))
+    val nginxDeploymentSpec=nginxBaseSpec.addLabels(nginxDeploymentLabels)
+    val nginxDeployment=Deployment("nginx-scale-depl")
+       .withReplicas(10)
+       .withLabelSelector(nginxDeploymentSel)
+       .withTemplate(nginxDeploymentSpec)
+
+    val nginxStsLabels=Map("scale-example-type" -> "statefulset")
+    val nginxStsSel=LabelSelector(LabelSelector.InRequirement("scale-example-type",List("statefulset")))
+    val nginxStsSpec=nginxBaseSpec.addLabels(nginxDeploymentLabels)
+    val nginxStatefulSet= StatefulSet("nginx-scale-sts")
+      .withReplicas(10)
+      .withServiceName("nginx-service")
+      .withLabelSelector(nginxStsSel)
+      .withTemplate(nginxStsSpec)
 
 
     implicit val system = ActorSystem()
@@ -28,31 +45,73 @@ object ScaleExamples extends App {
     implicit val dispatcher = system.dispatcher
 
     val k8s = k8sInit
-  
-    println("Creating nginx replication controller")
-    val createdRCFut = k8s create nginxController
-   
-    val rcFut = createdRCFut recoverWith {
+
+    // First scale up and down a deployment
+    println("Creating nginx deployment")
+
+    val createdDeplFut = k8s create nginxDeployment
+
+    val deplFut = createdDeplFut recoverWith {
       case ex: K8SException if (ex.status.code.contains(409)) => {
-        println("It seems the controller already exists - retrieving latest version")
-        k8s get[ReplicationController] nginxController.name
+        println("It seems the deployment already exists - retrieving latest version")
+        k8s get[Deployment] nginxDeployment.name
       }
     }
-    val directlyScale = for {
-        rc <- rcFut
-        _ = println("Directly Scaling replication controller down to 1 replica")
-        scaledDown <- k8s.scale(rc, 1)
-        _ = println("Scale object returned: specified = " + scaledDown.spec.replicas + ", current = " + scaledDown.status.get.replicas)
+    println("Directly deployment down to 1 replica")
+
+    val scaledDeploymentFut = for {
+      scaledDown <- k8s.scale[Deployment](nginxDeployment.name, 1)
+      _ = println("Scale desired = " + scaledDown.spec.replicas + ", current = " + scaledDown.status.get.replicas)
+      _ = println("Now directly scale up to 4 replicas")
+      scaledUp <- k8s.scale[Deployment](nginxDeployment.name, 4)
+      _ = println("Scale object returned: specified = " + scaledUp.spec.replicas + ", current = " + scaledUp.status.get.replicas)
+    } yield scaledUp
+
+    println("waiting one minute to allow scaling to progress before deleting deployment")
+    Thread.sleep(60000)
+    println("Deleting deployment")
+    k8s.deleteWithOptions[Deployment](nginxDeployment.name, DeleteOptions(propagationPolicy=Some(DeletePropagation.Foreground)))
+
+    println("Creating nginx stateful set")
+    val createdStsFut = k8s create nginxStatefulSet
+   
+    val stsFut = createdStsFut recoverWith {
+      case ex: K8SException if (ex.status.code.contains(409)) => {
+        println("It seems the stateful set already exists - retrieving latest version")
+        k8s get[StatefulSet] nginxStatefulSet.name
+      }
+    }
+    println("Directly scaling stateful set down to 1 replica")
+
+    val scaledStsFut = for {
+        scaledDown <- k8s.scale[StatefulSet](nginxStatefulSet.name, 1)
+        _ = println("Scale desired = " + scaledDown.spec.replicas + ", current = " + scaledDown.status.get.replicas)
         _ = println("Now directly scaling it up to 4 replicas")
-        scaledUp   <- k8s.scale(rc,4)
+        scaledUp   <- k8s.scale[StatefulSet](nginxStatefulSet.name, 4)
         _ = println("Scale object returned: specified = " + scaledUp.spec.replicas + ", current = " + scaledUp.status.get.replicas)   
-    } yield rc
-    
+    } yield scaledUp
+
+    println("waiting one minute to allow scaling to progress before deleting StatefulSet")
+    Thread.sleep(60000)
+    println("Deleting StatefulSet")
+    k8s.deleteWithOptions[StatefulSet](nginxStatefulSet.name, DeleteOptions(propagationPolicy=Some(DeletePropagation.Foreground)))
+
+    // Recreate the deployment, but this time to be scaled by a HPAS
+    println("Recreating deployment for use with HPAS")
+    val createdDeplFut2 = k8s create nginxDeployment
+
+    val deplFut2 = createdDeplFut2 recoverWith {
+      case ex: K8SException if (ex.status.code.contains(409)) => {
+        println("It seems the deployment already exists - retrieving latest version")
+        k8s get[Deployment] nginxDeployment.name
+      }
+    }
+
     val autoScale = for {
-      rc   <- directlyScale 
+      depl  <- deplFut2
       hpas <- {
         println("Now creating a HorizontalPodAutoscaler to automatically scale the replicas")
-        val hpas = HorizontalPodAutoscaler.scale(rc).
+        val hpas = HorizontalPodAutoscaler.scale(depl).
             withMinReplicas(2).
             withMaxReplicas(8).
             withCPUTargetUtilization(80)
@@ -80,5 +139,5 @@ object ScaleExamples extends App {
       }
     }
   }
-  scaleNginxController
+  scaleNginx
 }


### PR DESCRIPTION
This PR addresses several issues and enhancements related to StatefulSet and Scaling:
- fixes typo in its resource definition which resulted in incorrect API paths  being used for this type for some API methods
- created separate version of the StatefulSet class for legacy `v1beta1` version of the resource  type under `skuber.apps.v1beta1`. This version of the class should be used with k8s v1.7 and earlier.
- updated `skuber,apps.StatefulSet` class to support k8s v1.8, including adding support for scaling stateful sets via the scale subresource.
- refactored scaling API making it possible now to add support for scaling of new resource types without modifying the APi itself. Older methods still supported for now but deprecated.
- updated ScaleExamples example to demonstrate scaling using new API and include stateful set scaling