### PR TITLE
Added json merge patch support, with example

### DIFF
--- a/client/src/main/scala/skuber/apps/StatefulSet.scala
+++ b/client/src/main/scala/skuber/apps/StatefulSet.scala
@@ -1,7 +1,11 @@
 package skuber.apps
 
 import skuber.ResourceSpecification.{Names, Scope}
-import skuber.{LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, PersistentVolumeClaim, Pod, ResourceDefinition, Scale, Timestamp}
+import skuber._
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Format, JsPath, Json}
+import skuber.json.format._ // reuse some core skuber json formatters
 
 /**
   * Created by hollinwilkins on 4/5/17.
@@ -87,4 +91,34 @@ object StatefulSet {
                     collisionCount: Option[Int],
                     conditions: Option[List[Condition]])
 
+  // json formatters
+
+  implicit val statefulSetPodPcyMgmtFmt: Format[StatefulSet.PodManagementPolicyType.PodManagementPolicyType] = Format(enumReads(StatefulSet.PodManagementPolicyType, StatefulSet.PodManagementPolicyType.OrderedReady), enumWrites)
+  implicit val statefulSetRollUp: Format[StatefulSet.RollingUpdateStrategy] = Json.format[StatefulSet.RollingUpdateStrategy]
+  implicit val statefulSetUpdStrFmt: Format[StatefulSet.UpdateStrategy] = (
+      (JsPath \ "type").formatEnum(StatefulSet.UpdateStrategyType, Some(StatefulSet.UpdateStrategyType.RollingUpdate)) and
+          (JsPath \ "rollingUpdate").formatNullable[StatefulSet.RollingUpdateStrategy]
+      )(StatefulSet.UpdateStrategy.apply _,unlift(StatefulSet.UpdateStrategy.unapply))
+
+  implicit val statefulSetSpecFmt: Format[StatefulSet.Spec] = (
+      (JsPath \ "replicas").formatNullable[Int] and
+          (JsPath \ "serviceName").formatNullable[String] and
+          (JsPath \ "selector").formatNullableLabelSelector and
+          (JsPath \ "template").format[Pod.Template.Spec] and
+          (JsPath \ "volumeClaimTemplates").formatMaybeEmptyList[PersistentVolumeClaim] and
+          (JsPath \ "podManagmentPolicy").formatNullableEnum(StatefulSet.PodManagementPolicyType) and
+          (JsPath \ "updateStrategy").formatNullable[StatefulSet.UpdateStrategy] and
+          (JsPath \ "revisionHistoryLimit").formatNullable[Int]
+      )(StatefulSet.Spec.apply _, unlift(StatefulSet.Spec.unapply))
+
+  implicit val statefulSetCondFmt: Format[StatefulSet.Condition] = Json.format[StatefulSet.Condition]
+  implicit val statefulSetStatusFmt: Format[StatefulSet.Status] = Json.format[StatefulSet.Status]
+
+  implicit lazy val statefulSetFormat: Format[StatefulSet] = (
+    objFormat and
+      (JsPath \ "spec").formatNullable[StatefulSet.Spec] and
+      (JsPath \ "status").formatNullable[StatefulSet.Status]
+    ) (StatefulSet.apply _, unlift(StatefulSet.unapply))
+
+  implicit val statefulSetListFormat: Format[StatefulSetList] = ListResourceFormat[StatefulSet]
 }

--- a/client/src/main/scala/skuber/apps/v1beta1/StatefulSet.scala
+++ b/client/src/main/scala/skuber/apps/v1beta1/StatefulSet.scala
@@ -1,7 +1,11 @@
 package skuber.apps.v1beta1
 
+import skuber._
 import skuber.ResourceSpecification.{Names, Scope}
-import skuber.{LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, PersistentVolumeClaim, Pod, ResourceDefinition, Scale, Timestamp}
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Format, JsPath, Json}
+import skuber.json.format._
 
 /**
   * Created by hollinwilkins on 4/5/17.
@@ -84,4 +88,34 @@ object StatefulSet {
                     collisionCount: Option[Int],
                     conditions: Option[List[Condition]])
 
+  // Stateful set formatters
+  implicit val statefulSetPodPcyMgmtFmt: Format[StatefulSet.PodManagementPolicyType.PodManagementPolicyType] = Format(enumReads(StatefulSet.PodManagementPolicyType, StatefulSet.PodManagementPolicyType.OrderedReady), enumWrites)
+  implicit val statefulSetRollUp: Format[StatefulSet.RollingUpdateStrategy] = Json.format[StatefulSet.RollingUpdateStrategy]
+  implicit val statefulSetUpdStrFmt: Format[StatefulSet.UpdateStrategy] = (
+      (JsPath \ "type").formatEnum(StatefulSet.UpdateStrategyType, Some(StatefulSet.UpdateStrategyType.RollingUpdate)) and
+          (JsPath \ "rollingUpdate").formatNullable[StatefulSet.RollingUpdateStrategy]
+      )(StatefulSet.UpdateStrategy.apply _,unlift(StatefulSet.UpdateStrategy.unapply))
+
+
+  implicit val statefulSetSpecFmt: Format[StatefulSet.Spec] = (
+      (JsPath \ "replicas").formatNullable[Int] and
+          (JsPath \ "serviceName").formatNullable[String] and
+          (JsPath \ "selector").formatNullableLabelSelector and
+          (JsPath \ "template").format[Pod.Template.Spec] and
+          (JsPath \ "volumeClaimTemplates").formatMaybeEmptyList[PersistentVolumeClaim] and
+          (JsPath \ "podManagmentPolicy").formatNullableEnum(StatefulSet.PodManagementPolicyType) and
+          (JsPath \ "updateStrategy").formatNullable[StatefulSet.UpdateStrategy] and
+          (JsPath \ "revisionHistoryLimit").formatNullable[Int]
+      )(StatefulSet.Spec.apply _, unlift(StatefulSet.Spec.unapply))
+
+  implicit val statefulSetCondFmt: Format[StatefulSet.Condition] = Json.format[StatefulSet.Condition]
+  implicit val statefulSetStatusFmt: Format[StatefulSet.Status] = Json.format[StatefulSet.Status]
+
+  implicit lazy val statefulSetFormat: Format[StatefulSet] = (
+      objFormat and
+          (JsPath \ "spec").formatNullable[StatefulSet.Spec] and
+          (JsPath \ "status").formatNullable[StatefulSet.Status]
+      ) (StatefulSet.apply _, unlift(StatefulSet.unapply))
+
+  implicit val statefulSetListFormat: Format[StatefulSetList] = ListResourceFormat[StatefulSet]
 }

--- a/client/src/main/scala/skuber/json/apps/format/package.scala
+++ b/client/src/main/scala/skuber/json/apps/format/package.scala
@@ -46,35 +46,5 @@ package object format {
     (JsPath \ "status").formatNullable[Deployment.Status]
   )(Deployment.apply _, unlift(Deployment.unapply))
 
-  // Stateful set formatters
-  implicit val statefulSetPodPcyMgmtFmt: Format[StatefulSet.PodManagementPolicyType.PodManagementPolicyType] = Format(enumReads(StatefulSet.PodManagementPolicyType, StatefulSet.PodManagementPolicyType.OrderedReady), enumWrites)
-  implicit val statefulSetRollUp: Format[StatefulSet.RollingUpdateStrategy] = Json.format[StatefulSet.RollingUpdateStrategy]
-  implicit val statefulSetUpdStrFmt: Format[StatefulSet.UpdateStrategy] = (
-    (JsPath \ "type").formatEnum(StatefulSet.UpdateStrategyType, Some(StatefulSet.UpdateStrategyType.RollingUpdate)) and
-    (JsPath \ "rollingUpdate").formatNullable[StatefulSet.RollingUpdateStrategy]
-  )(StatefulSet.UpdateStrategy.apply _,unlift(StatefulSet.UpdateStrategy.unapply))
-
-
-  implicit val statefulSetSpecFmt: Format[StatefulSet.Spec] = (
-    (JsPath \ "replicas").formatNullable[Int] and
-    (JsPath \ "serviceName").formatNullable[String] and
-    (JsPath \ "selector").formatNullableLabelSelector and
-    (JsPath \ "template").format[Pod.Template.Spec] and
-    (JsPath \ "volumeClaimTemplates").formatMaybeEmptyList[PersistentVolumeClaim] and
-    (JsPath \ "podManagmentPolicy").formatNullableEnum(StatefulSet.PodManagementPolicyType) and
-    (JsPath \ "updateStrategy").formatNullable[StatefulSet.UpdateStrategy] and
-    (JsPath \ "revisionHistoryLimit").formatNullable[Int]
-  )(StatefulSet.Spec.apply _, unlift(StatefulSet.Spec.unapply))
-
-  implicit val statefulSetCondFmt: Format[StatefulSet.Condition] = Json.format[StatefulSet.Condition]
-  implicit val statefulSetStatusFmt: Format[StatefulSet.Status] = Json.format[StatefulSet.Status]
-
-  implicit lazy val statefulSetFormat: Format[StatefulSet] = (
-    objFormat and
-      (JsPath \ "spec").formatNullable[StatefulSet.Spec] and
-      (JsPath \ "status").formatNullable[StatefulSet.Status]
-    ) (StatefulSet.apply _, unlift(StatefulSet.unapply))
-
-  implicit val statefulSetListFormat: Format[StatefulSetList] = ListResourceFormat[StatefulSet]
   implicit val deployListFormat: Format[DeploymentList] = ListResourceFormat[Deployment]
 }

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -490,7 +490,6 @@ import Pod._
     }
 
     "a statefulset with pod affinity/anti-affinity can be read and written as json successfully" >> {
-      import skuber.json.apps.format.statefulSetFormat
       val ssJsonSource=Source.fromURL(getClass.getResource("/exampleStatefulSetWithPodAffinity.json"))
       val ssJsonStr = ssJsonSource.mkString
       val ss = Json.parse(ssJsonStr).as[StatefulSet]

--- a/examples/src/main/scala/skuber/examples/patch/PatchExamples.scala
+++ b/examples/src/main/scala/skuber/examples/patch/PatchExamples.scala
@@ -1,0 +1,104 @@
+package skuber.examples.patch
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import skuber._
+import skuber.json.format._
+import skuber.apps.v1beta1.StatefulSet
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration.Inf
+
+import play.api.libs.json.{Format, Json}
+/**
+ * @author David O'Riordan
+ * 
+ * Some simple examples of patching Kubernetes resources
+ * This initial version scales an example StatefulSet by updatng its replica count using a basic JSON merge patch
+ * (see https://tools.ietf.org/html/rfc7386)
+ */
+object PatchExamples extends App {
+
+  // A model - with implicit JSON formatters - of the specific JSON merge patch we are going to send to the server in this example.
+  // The resulting JSON will look like `{ "spec" : { "replicas" : <replicas> } }`, and will be converted to a String for sending via the
+  // API jsonMergePatch method.
+  // This will change the replica count on the statefulset causing it to scale accordingly.
+  // Clients do not need to make a model with JSON formatters to send a patch, as the API method takes the patch JSON as a String type, but
+  // this pattern ensures valid JSON is sent
+  case class ReplicaSpec(replicas: Int)
+  case class ReplicaPatch(spec: ReplicaSpec)
+
+  implicit val rsFmt: Format[ReplicaSpec] = Json.format[ReplicaSpec]
+  implicit val rpFmt: Format[ReplicaPatch] = Json.format[ReplicaPatch]
+
+  def scaleNginx = {
+
+    val nginxContainer = Container("nginx",image="nginx").exposePort(80)
+    val nginxBaseSpec = Pod.Template.Spec().addContainer(nginxContainer)
+
+
+    val nginxStsLabels=Map("patch-example" -> "statefulset")
+    val nginxStsSel=LabelSelector(LabelSelector.IsEqualRequirement("patch-example","statefulset"))
+    val nginxStsSpec=nginxBaseSpec.addLabels(nginxStsLabels)
+    val nginxStatefulSet= StatefulSet("nginx-patch-sts")
+      .withReplicas(4)
+      .withServiceName("nginx-patch-sts")
+      .withLabelSelector(nginxStsSel)
+      .withTemplate(nginxStsSpec)
+
+    // StatefulSet needs a headless service
+    val nginxStsService: Service=Service(nginxStatefulSet.spec.get.serviceName.get, nginxStsLabels, 80).isHeadless
+
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+    implicit val dispatcher = system.dispatcher
+
+    val k8s = k8sInit
+
+    println("Creating nginx stateful set")
+    val createdStsFut = for {
+      svc <- k8s create nginxStsService
+      sts <- k8s create nginxStatefulSet
+    } yield sts
+   
+    val stsFut = createdStsFut recoverWith {
+      case ex: K8SException if (ex.status.code.contains(409)) => {
+        println("It seems the stateful set or service already exists - retrieving latest version")
+        k8s get[StatefulSet] nginxStatefulSet.name
+      }
+    }
+
+    // Wait for stateful set creation before proceeding
+    val sts = Await.result(stsFut, Inf)
+    println("waiting two minutes to allow Stateful Set creation to complete before patching it")
+    Thread.sleep(120000)
+
+
+    println("Patching stateful set to assign replica count of 1")
+
+    // Create the Patch
+    val singleReplicaPatch=ReplicaPatch(ReplicaSpec(1))
+    val singleReplicaPatchJson=Json.toJson(singleReplicaPatch)
+    val singleReplicaPatchJsonStr=singleReplicaPatchJson.toString
+
+    // Send the Patch to the statefulset on Kubernetes
+    val patchedStsFut = k8s.jsonMergePatch(sts, singleReplicaPatchJsonStr)
+
+    val patchedSts = Await.result(patchedStsFut, Inf)
+    println(s"Patched statefulset now has a desired replica count of ${patchedSts.spec.get.replicas}")
+    println("waiting 5 minutes to allow scaling to be observed before cleaning up")
+    Thread.sleep(300000)
+    println("will now delete StatefulSet and its service")
+    val cleanupRequested= for {
+      sts <- k8s.deleteWithOptions[StatefulSet](nginxStatefulSet.name, DeleteOptions(propagationPolicy = Some(DeletePropagation.Foreground)))
+      done <- k8s.delete[Service](nginxStsService.name)
+    } yield done
+
+
+    Await.ready(cleanupRequested, Inf)
+    println("Finishing up")
+    k8s.close
+    system.terminate()
+  }
+  scaleNginx
+}


### PR DESCRIPTION
Adds a new `jsonMergePatch` method to the API, which supports making patches to Kubernetes resources using the [merge patch](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#patch-operations) strategy. Also includes an example of patching a StatefulSets replica count to scale it.
Note: Basic `json patch` and `strategic merge patch` strategies not yet supported, intended to be supported via future PRs 