### PR TITLE
#84 - Get configuration from running pod mounted config folder

### DIFF
--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -693,9 +693,9 @@ package object client {
             kubeConfigEnv.map { kc =>
               Configuration.parseKubeconfigFile(Paths.get(kc))
             }.getOrElse {
-              //Try to get config from a running pod -
+              // Try to get config from a running pod
               // if that is not set then use default kubeconfig location
-              Configuration.useRunningPod.flatMap(_ =>
+              Configuration.useRunningPod.orElse(
                 Configuration.parseKubeconfigFile()
               )
             }.get

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -688,13 +688,17 @@ package object client {
             val path = Paths.get(new URL(fileUrl).toURI)
             Configuration.parseKubeconfigFile(path).get
           case None =>
-            // try KUBECONFIG - if that is not set then use default kubeconfig location
+            // try KUBECONFIG
             val kubeConfigEnv = sys.env.get("KUBECONFIG")
             kubeConfigEnv.map { kc =>
               Configuration.parseKubeconfigFile(Paths.get(kc))
-            }.getOrElse(
-              Configuration.parseKubeconfigFile()
-            ).get
+            }.getOrElse {
+              //Try to get config from a running pod -
+              // if that is not set then use default kubeconfig location
+              Configuration.useRunningPod.flatMap(_ =>
+                Configuration.parseKubeconfigFile()
+              )
+            }.get
         }
     }
   }


### PR DESCRIPTION
#84 - Support for getting the configuration from a running pod

Will get the configuration from the mounted folder `/var/run/secrets/kubernetes.io/serviceaccount` in a running pod