### PR TITLE
Extended supported node status fields; added support for taints

### DIFF
--- a/client/src/main/scala/skuber/Container.scala
+++ b/client/src/main/scala/skuber/Container.scala
@@ -168,4 +168,9 @@ object Container {
     type TerminationMessagePolicy = Value
     val File, FallbackToLogsOnError = Value
   }
+
+  case class Image(
+    names: List[String] = Nil,
+    sizeBytes: Option[Int] = None
+  )
 }    

--- a/client/src/main/scala/skuber/Node.scala
+++ b/client/src/main/scala/skuber/Node.scala
@@ -39,15 +39,39 @@ object Node {
       podCIDR: String = "",
       providerID: String = "",
       unschedulable: Boolean = false,
-      externalID: String = "")
-      
+      externalID: String = "",
+      taints: List[Taint] = Nil)
+
+  case class Taint(
+    effect: String,
+    key: String,
+    value: String,
+    timeAdded: Option[Timestamp] = None
+  )
+
   case class Status(
       capacity: Resource.ResourceList=Map(),
       phase: Option[Phase.Phase] = None,
       conditions: List[Node.Condition] = List(),
       addresses: List[Node.Address] = List(),
-      nodeInfo: Option[Node.SystemInfo] = None)
-      
+      nodeInfo: Option[Node.SystemInfo] = None,
+      allocatable: Resource.ResourceList=Map(),
+      daemonEndpoints: Option[DaemonEndpoints] = None,
+      images: List[Container.Image] = Nil,
+      volumesInUse: List[String] = Nil,
+      volumesAttached: List[AttachedVolume]
+  )
+
+  case class DaemonEndpoints(
+    kubeletEndpoint: DaemonEndpoint
+  )
+
+  case class DaemonEndpoint(
+    Port: Int
+  )
+
+  case class AttachedVolume(name: String, devicePath: String)
+
   object Phase extends Enumeration {
      type Phase = Value
      val Pending, Running,Terminated = Value

--- a/client/src/main/scala/skuber/Resource.scala
+++ b/client/src/main/scala/skuber/Resource.scala
@@ -40,6 +40,7 @@ object Resource {
   val cpu = "cpu"
   val memory="memory"
   val storage="storage"
+  val pods = "pods"
   
   // K8 has a specific format for Resource Quantity type - see
   // https://godoc.org/github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource#Quantity

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -642,7 +642,12 @@ package object format {
     (JsPath \ "tty").formatNullable[Boolean] and
     (JsPath \ "volumeDevices").formatMaybeEmptyList[Volume.Device]
   )(Container.apply _, unlift(Container.unapply))
-   
+
+  implicit val cntnrImageFmt: Format[Container.Image] = (
+    (JsPath \ "names").formatMaybeEmptyList[String] and
+    (JsPath \ "sizeBytes").formatNullable[Int]
+  )(Container.Image.apply _, unlift(Container.Image.unapply))
+
   implicit val podStatusCondFormat : Format[Pod.Condition] = (
       (JsPath \ "type").format[String] and
       (JsPath \ "status").formatMaybeEmptyString() and
@@ -807,22 +812,34 @@ package object format {
     (JsPath \ "reason").formatNullable[String] and
     (JsPath \ "message").formatNullable[String]
   )(Node.Condition.apply _, unlift(Node.Condition.unapply))
-  
+
+  implicit val nodeDaemEndpFmt: Format[Node.DaemonEndpoint] = Json.format[Node.DaemonEndpoint]
+  implicit val nodeDaemEndpsFmt: Format[Node.DaemonEndpoints] = Json.format[Node.DaemonEndpoints]
+  implicit val nodeAttachedVolFmt: Format[Node.AttachedVolume] = Json.format[Node.AttachedVolume]
+
   implicit val nodeStatusFmt: Format[Node.Status] = (
     (JsPath \ "capacity").formatMaybeEmptyMap[Resource.Quantity] and
     (JsPath \ "phase").formatNullableEnum(Node.Phase) and
     (JsPath \ "conditions").formatMaybeEmptyList[Node.Condition] and
     (JsPath \ "addresses").formatMaybeEmptyList[Node.Address] and
-    (JsPath \ "nodeInfo").formatNullable[Node.SystemInfo]
+    (JsPath \ "nodeInfo").formatNullable[Node.SystemInfo] and
+    (JsPath \ "allocatable").formatMaybeEmptyMap[Resource.Quantity] and
+    (JsPath \ "daemonEndpoints").formatNullable[Node.DaemonEndpoints] and
+    (JsPath \ "images").formatMaybeEmptyList[Container.Image] and
+    (JsPath \ "volumesInUse").formatMaybeEmptyList[String] and
+    (JsPath \ "volumesAttached").formatMaybeEmptyList[Node.AttachedVolume]
   )(Node.Status.apply _, unlift(Node.Status.unapply)) 
-   
+
+  implicit val nodeTaintFmt: Format[Node.Taint] = Json.format[Node.Taint]
+
   implicit val nodeSpecFmt: Format[Node.Spec] =(
     (JsPath \ "podCIDR").formatMaybeEmptyString() and
     (JsPath \ "providerID").formatMaybeEmptyString() and
     (JsPath \ "unschedulable").formatMaybeEmptyBoolean() and
-    (JsPath \ "externalID").formatMaybeEmptyString()
+    (JsPath \ "externalID").formatMaybeEmptyString() and
+    (JsPath \ "taints").formatMaybeEmptyList[Node.Taint]
   )(Node.Spec.apply _, unlift(Node.Spec.unapply))
- 
+
   implicit val nodeFmt: Format[Node] = (
     objFormat and
     (JsPath \ "spec").formatNullable[Node.Spec] and

--- a/client/src/test/resources/exampleNode.json
+++ b/client/src/test/resources/exampleNode.json
@@ -1,0 +1,177 @@
+{
+  "apiVersion": "v1",
+  "kind": "Node",
+  "metadata": {
+    "annotations": {
+      "alpha.kubernetes.io/provided-node-ip": "192.168.99.100",
+      "node.alpha.kubernetes.io/ttl": "0",
+      "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+    },
+    "creationTimestamp": "2018-01-28T11:53:03Z",
+    "labels": {
+      "beta.kubernetes.io/arch": "amd64",
+      "beta.kubernetes.io/os": "linux",
+      "kubernetes.io/hostname": "minikube"
+    },
+    "name": "minikube",
+    "resourceVersion": "1617567",
+    "selfLink": "/api/v1/nodes/minikube",
+    "uid": "cbdbe942-0421-11e8-836b-08002754f629"
+  },
+  "spec": {
+    "externalID": "minikube",
+    "taints": [
+      {
+        "effect": "NoSchedule",
+        "key": "key",
+        "timeAdded": null,
+        "value": "value"
+      }
+    ]
+  },
+  "status": {
+    "addresses": [
+      {
+        "address": "192.168.99.100",
+        "type": "InternalIP"
+      },
+      {
+        "address": "minikube",
+        "type": "Hostname"
+      }
+    ],
+    "allocatable": {
+      "cpu": "2",
+      "memory": "1945676Ki",
+      "pods": "110"
+    },
+    "capacity": {
+      "cpu": "2",
+      "memory": "2048076Ki",
+      "pods": "110"
+    },
+    "conditions": [
+      {
+        "lastHeartbeatTime": "2018-05-07T11:30:51Z",
+        "lastTransitionTime": "2018-02-08T12:39:11Z",
+        "message": "kubelet has sufficient disk space available",
+        "reason": "KubeletHasSufficientDisk",
+        "status": "False",
+        "type": "OutOfDisk"
+      },
+      {
+        "lastHeartbeatTime": "2018-05-07T11:30:51Z",
+        "lastTransitionTime": "2018-02-08T12:39:11Z",
+        "message": "kubelet has sufficient memory available",
+        "reason": "KubeletHasSufficientMemory",
+        "status": "False",
+        "type": "MemoryPressure"
+      },
+      {
+        "lastHeartbeatTime": "2018-05-07T11:30:51Z",
+        "lastTransitionTime": "2018-02-08T12:39:11Z",
+        "message": "kubelet has no disk pressure",
+        "reason": "KubeletHasNoDiskPressure",
+        "status": "False",
+        "type": "DiskPressure"
+      },
+      {
+        "lastHeartbeatTime": "2018-05-07T11:30:51Z",
+        "lastTransitionTime": "2018-05-07T11:30:41Z",
+        "message": "kubelet is posting ready status",
+        "reason": "KubeletReady",
+        "status": "True",
+        "type": "Ready"
+      }
+    ],
+    "daemonEndpoints": {
+      "kubeletEndpoint": {
+        "Port": 10250
+      }
+    },
+    "images": [
+      {
+        "names": [
+          "nginx@sha256:2f68b99bc0d6d25d0c56876b924ec20418544ff28e1fb89a4c27679a40da811b",
+          "nginx:1.9.1"
+        ],
+        "sizeBytes": 132835913
+      },
+      {
+        "names": [
+          "gcr.io/google_containers/kubernetes-dashboard-amd64@sha256:71a0de5c6a21cb0c2fbcad71a4fef47acd3e61cd78109822d35e1742f9d8140d",
+          "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.8.0"
+        ],
+        "sizeBytes": 119155776
+      },
+      {
+        "names": [
+          "nginx@sha256:285b49d42c703fdf257d1e2422765c4ba9d3e37768d6ea83d7fe2043dad6e63d",
+          "nginx:latest"
+        ],
+        "sizeBytes": 108492271
+      },
+      {
+        "names": [
+          "nginx@sha256:e3456c851a152494c3e4ff5fcc26f240206abac0c9d794affb40e0714846c451",
+          "nginx:1.7.9"
+        ],
+        "sizeBytes": 91664166
+      },
+      {
+        "names": [
+          "gcr.io/k8s-minikube/storage-provisioner@sha256:088daa9fcbccf04c3f415d77d5a6360d2803922190b675cb7fc88a9d2d91985a",
+          "gcr.io/k8s-minikube/storage-provisioner:v1.8.1"
+        ],
+        "sizeBytes": 80815640
+      },
+      {
+        "names": [
+          "gcr.io/google-containers/kube-addon-manager@sha256:3e6ff32eb762ecf17d817c49372f4fe51052d3406772ddb0a65f89c478070b96",
+          "gcr.io/google-containers/kube-addon-manager:v6.4-beta.2"
+        ],
+        "sizeBytes": 79238665
+      },
+      {
+        "names": [
+          "gcr.io/google_containers/k8s-dns-kube-dns-amd64@sha256:1a3fc069de481ae690188f6f1ba4664b5cc7760af37120f70c86505c79eea61d",
+          "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
+        ],
+        "sizeBytes": 49387411
+      },
+      {
+        "names": [
+          "gcr.io/google_containers/k8s-dns-sidecar-amd64@sha256:9aab42bf6a2a068b797fe7d91a5d8d915b10dbbc3d6f2b10492848debfba6044",
+          "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
+        ],
+        "sizeBytes": 41819177
+      },
+      {
+        "names": [
+          "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64@sha256:46b933bb70270c8a02fa6b6f87d440f6f1fce1a5a2a719e164f83f7b109f7544",
+          "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
+        ],
+        "sizeBytes": 41423617
+      },
+      {
+        "names": [
+          "gcr.io/google_containers/pause-amd64@sha256:163ac025575b775d1c0f9bf0bdd0f086883171eb475b5068e7defa4ca9e76516",
+          "gcr.io/google_containers/pause-amd64:3.0"
+        ],
+        "sizeBytes": 746888
+      }
+    ],
+    "nodeInfo": {
+      "architecture": "amd64",
+      "bootID": "6075c7d8-ba52-4e8c-e674-bbc687423022",
+      "containerRuntimeVersion": "docker://Unknown",
+      "kernelVersion": "4.9.13",
+      "kubeProxyVersion": "v1.8.0",
+      "kubeletVersion": "v1.8.0",
+      "machineID": "4d2e89adb7945819fe191feabe1f8c6",
+      "operatingSystem": "linux",
+      "osImage": "Buildroot 2017.02",
+      "systemUUID": "DF9671CC-A6C6-4DB4-966A-FE956D4FBAAA"
+    }
+  }
+}


### PR DESCRIPTION
* Support added for following fields in Node status:
  - allocatable
  - images
  - daemonEndpoints
  - volumesInUse
  - volumesAttached
* Added support for taints (Node.Taint)