### PR TITLE
Make watch request idle timeout configurable

### DIFF
--- a/client/src/main/resources/reference.conf
+++ b/client/src/main/resources/reference.conf
@@ -4,4 +4,9 @@ skuber {
     # The ID of the dispatcher to use by Skuber. If undefined or empty the default Akka dispatcher is used.
     dispatcher = ""
   }
+
+  watch {
+    # The idle timeout duration for any connections used by skuber `watch` requests - if null the timeout is infinite.
+    idle-timeout = null
+  }
 }

--- a/client/src/main/scala/skuber/api/Watch.scala
+++ b/client/src/main/scala/skuber/api/Watch.scala
@@ -40,7 +40,7 @@ object Watch {
 
     val maybeResourceVersionQuery = sinceResourceVersion map { version => Uri.Query("resourceVersion" -> version) }
     val request = context.buildRequest(HttpMethods.GET, rd, Some(name), query = maybeResourceVersionQuery, watch = true)
-    val responseFut = context.invoke(request)
+    val responseFut = context.invoke(request, true)
     toFutureWatchEventSource(context, responseFut, bufSize)
   }
 
@@ -61,7 +61,7 @@ object Watch {
 
     val maybeResourceVersionQuery = sinceResourceVersion map { v => Uri.Query("resourceVersion" -> v) }
     val request = context.buildRequest(HttpMethods.GET, rd, None, query = maybeResourceVersionQuery, watch = true)
-    val responseFut = context.invoke(request)
+    val responseFut = context.invoke(request, true)
     toFutureWatchEventSource(context, responseFut, bufSize)
   }
 

--- a/examples/src/main/scala/skuber/examples/watch/WatchExamples.scala
+++ b/examples/src/main/scala/skuber/examples/watch/WatchExamples.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Sink
  */
 object WatchExamples extends App {
 
-  implicit val system = ActorSystem()
+  implicit val system = ActorSystem("watch")
   implicit val materializer = ActorMaterializer()
   implicit val dispatcher = system.dispatcher
   implicit val k8s = k8sInit
@@ -46,11 +46,11 @@ object WatchExamples extends App {
     } yield done
   }
 
-  // Note: other examples (e.g. guestbook) need to be running for the following watches to have any events to output
+  // Note: run appropriate kubectl commands (like 'run') or an example like gueestbook to see events being output
   watchPodPhases
   watchFrontEndScaling
 
-  Thread.sleep(30000) // watch for some time before closing the session
+  Thread.sleep(1200000) // watch for a lengthy time before closing the session
   k8s.close
   system.terminate().foreach { f =>
     System.exit(0)


### PR DESCRIPTION
- watch requests now have an idle timeout setting distinct from the setting that applies to other Skuber requests
- the default watch idle timeout duration is now infinite 
- that duration is configurable via app config ("skuber.watch.idle-timeout" value)
- watch example modified to run for longer 