### PR TITLE
Extend pod spec to include missing fields and values

### DIFF
--- a/client/src/main/scala/skuber/Pod.scala
+++ b/client/src/main/scala/skuber/Pod.scala
@@ -22,8 +22,7 @@ object Pod {
 
   def named(name: String) = Pod(metadata=ObjectMeta(name=name))
   def apply(name: String, spec: Pod.Spec) : Pod = Pod(metadata=ObjectMeta(name=name), spec = Some(spec))
-  
-  import DNSPolicy._
+
   case class Spec(
     containers: List[Container] = List(), // should have at least one member
     initContainers: List[Container] = Nil,
@@ -31,7 +30,7 @@ object Pod {
     restartPolicy: RestartPolicy.RestartPolicy = RestartPolicy.Always,
     terminationGracePeriodSeconds: Option[Int] = None,
     activeDeadlineSeconds: Option[Int] = None,
-    dnsPolicy: DNSPolicy.DNSPolicy = ClusterFirst,
+    dnsPolicy: DNSPolicy.DNSPolicy = DNSPolicy.ClusterFirst,
     nodeSelector: Map[String, String] = Map(),
     serviceAccountName: String ="",
     nodeName: String = "",
@@ -39,7 +38,17 @@ object Pod {
     imagePullSecrets: List[LocalObjectReference] = List(),
     affinity: Option[Affinity] = None,
     tolerations: List[Toleration] = List(),
-    securityContext: Option[Security.Context] = None) {
+    securityContext: Option[Security.Context] = None,
+    hostname: Option[String] = None,
+    hostAliases: List[HostAlias] = Nil,
+    hostPID: Option[Boolean] = None,
+    hostIPC: Option[Boolean] = None,
+    automountServiceAccountToken: Option[Boolean] = None,
+    priority: Option[Int] = None,
+    priorityClassName: Option[String] = None,
+    schedulerName: Option[String] = None,
+    subdomain: Option[String] = None,
+    dnsConfig: Option[DNSConfig] = None) {
      
     // a few convenience methods for fluently building out a pod spec
     def addContainer(c: Container) = { this.copy(containers = c :: containers) }
@@ -138,6 +147,10 @@ object Pod {
     case class WeightedPodAffinityTerm(weight: Int, podAffinityTerm: PodAffinityTerm)
   }
 
+  case class HostAlias(ip: String, hostnames: List[String])
+  case class DNSConfigOption(name: String, value: String)
+  case class DNSConfig(nameservers: List[String] = Nil, options: List[DNSConfigOption] = Nil, searches: List[String] = Nil)
+
   case class Status(
     phase: Option[Phase.Phase] = None,
     conditions: List[Condition] = Nil,
@@ -146,7 +159,10 @@ object Pod {
     hostIP: Option[String] = None,
     podIP: Option[String] = None,
     startTime: Option[Timestamp] = None,
-    containerStatuses: List[Container.Status] = Nil)
+    containerStatuses: List[Container.Status] = Nil,
+    initContainerStatuses: List[Container.Status] = Nil,
+    qosClass: Option[String] = None,
+    nominatedNodeName: Option[String] = None)
 
   case class Condition(
     _type : String="Ready",

--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -212,7 +212,7 @@ package object skuber {
   }
   object DNSPolicy extends Enumeration {
      type DNSPolicy = Value
-     val Default,ClusterFirst = Value
+     val Default,ClusterFirst,ClusterFirstWithHostNet,None = Value
   }
    object RestartPolicy extends Enumeration {
      type RestartPolicy = Value

--- a/client/src/test/resources/examplePodExtendedSpec.json
+++ b/client/src/test/resources/examplePodExtendedSpec.json
@@ -13,11 +13,15 @@
     "serviceAccountName": "my-account",
     "terminationGracePeriodSeconds": 60,
     "hostNetwork": true,
+    "dnsPolicy": "None",
     "imagePullSecrets": [
       {
        "name": "secret"
       }
     ],
+    "priority": 2,
+    "hostname": "abc",
+    "subdomain": "def",
     "containers": [
       {
         "name": "basic",

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -560,7 +560,12 @@ import Pod._
     mount.readOnly mustEqual true
     mount.subPath mustEqual "subpath"
 
-    pod.spec.get.securityContext.get.fsGroup == Some(2000)
+    pod.spec.get.securityContext.get.fsGroup mustEqual Some(2000)
+    pod.spec.get.priority mustEqual Some(2)
+    pod.spec.get.hostname mustEqual Some("abc")
+    pod.spec.get.subdomain mustEqual Some("def")
+    pod.spec.get.dnsPolicy mustEqual DNSPolicy.None
+    pod.spec.get.hostNetwork mustEqual true
 
     // write and read it back in again and compare
     val json = Json.toJson(pod)


### PR DESCRIPTION
- Adds support for specifying pod spec items that are supported in recent versions of Kubernetes but not previously in Skuber: `hostname`,`subdomain`,`hostAliases`,`hostPID`,`hostIPC`,`automountServiceAccountToken`,`priority`,`priorityClassName`,`schedulerName`,`dnsConfig`
- Adds support for pod status fields `initContainers`,`qosClass` and `nominatedNodeName`
- Adds support for DNS policies `ClusterFirstWithHostNet` and `None`