### PR TITLE
Fix akka version compatibility issue in connection settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ scalacOptions += "-target:jvm-1.8"
 
 scalacOptions in Test ++= Seq("-Yrangepos")
 
-version in ThisBuild := "2.0.7"
+version in ThisBuild := "2.0.8"
 
 sonatypeProfileName := "io.skuber"
 

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -782,7 +782,7 @@ package object client {
 
     val defaultClientSettings=ConnectionPoolSettings(actorSystem.settings.config)
     val watchConnectionSettings=defaultClientSettings.connectionSettings.withIdleTimeout(watchIdleTimeout)
-    val watchSettings=defaultClientSettings.copy(connectionSettings = watchConnectionSettings)
+    val watchSettings=defaultClientSettings.withConnectionSettings(watchConnectionSettings)
 
     val requestInvoker = (request: HttpRequest, watch: Boolean) => {
       if (!watch)


### PR DESCRIPTION
This fixes an issue caused by a change introduced in v2.0.6.
That change introduced an incompatibility of the skuber client library (which uses Akka Http 1.0.10 currently) with any applications that use Akka http 1.0.11 and possibly other versions.
The incompatibility resulted in a NoSuchMethodError being thrown on initialisation of the client.
