### PR TITLE
Custom resource enhancements

### DIFF
--- a/client/src/it/scala/skuber/CustomResourceSpec.scala
+++ b/client/src/it/scala/skuber/CustomResourceSpec.scala
@@ -13,58 +13,110 @@ import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
 /**
+  * This tests making requests on custom resources based on a very simple custom resource type (TestResource) defined
+  * here. (A TestResource consists of a desired replica count (spec) and corresponding actual replicas count (status))
+  *
+  * The tests cover the following interactions with Kubernetes via skuber:
+  * - creating an appropriate Custom Resource Definition (CRD) for TestResource type
+  * - retrieving the CRD
+  * - creating TestResource custom resources
+  * - retrieving  TestResource resources
+  * - updating TestResource status (via status subresource)
+  * - scaling TestResource replica count (via scale subresource)
+  * - retrieval of list of TestResources
+  * - watch events on TestResources
+  * - deleting TestResources
+  * - and finally the CRD is deleted
+  *
+  * Note the test requires the CustomResourceSubresources feature to be enabled (at time of writing it is an alpha feature)
+  * on the Kubernetes cluster, so requires v1.10 or later of Kubernetes - on k8s v1.10 it needs a feature gate enabled,
+  * but on v1.11 it is enabled by default.
+  *
+  * Initially tested using minikube initialised as follows:
+  * 'minikube start --kubernetes-version=v1.10.0 --feature-gates=CustomResourceSubresources=true'
+  *
   * @author David O'Riordan
   */
 class CustomResourceSpec extends K8SFixture with Eventually with Matchers {
 
     val testResourceName: String = java.util.UUID.randomUUID().toString
 
-    case class TestSpec(desiredReplicas: Int)
-    case class TestStatus(actualReplicas: Int)
-
-    implicit val specFmt:Format[TestSpec] =Json.format[TestSpec]
-    implicit val statusFmt:Format[TestStatus] =Json.format[TestStatus]
-
-    type TestResource=CustomResource[TestSpec,TestStatus]
+    // Convenient aliases for the custom object and list resource types to be passed to the skuber API methods
+    type TestResource=CustomResource[TestResource.Spec,TestResource.Status]
     type TestResourceList=ListResource[TestResource]
 
+    object TestResource {
 
-    implicit val testResourceDefinition = ResourceDefinition[TestResource](
-      group = "test.skuber.io",
-      version = "v1alpha1",
-      kind = "SkuberTest",
-      shortNames = List("test","tests"),
-      subresources = Some(Subresources()
-        .withStatusSubresource
-        .withScaleSubresource(ScaleSubresource(".spec.desiredReplicas",".status.actualReplicas"))
+      /*
+       * Define the CustomResource model (spec and status), the implicit values that need to be passed to the
+       * skuber API to enable it to send and receive TestResource/TestResourceList types, and the matching CRD
+      */
+
+      // TestResource model
+      case class Spec(desiredReplicas: Int)
+      case class Status(actualReplicas: Int)
+
+      // skuber requires these implicit json formatters to marshal and unmarshal the TestResource spec and status fields.
+      // The CustomResource json formatter will marshal/unmarshal these to/from "spec" and "status" subobjects
+      // of the overall json representation of the resource.
+      implicit val specFmt: Format[Spec] = Json.format[Spec]
+      implicit val statusFmt: Format[Status] = Json.format[Status]
+
+      // Resource definition: defines the details of the API for the resource type on Kubernetes
+      // Must mirror the corresponding details in the associated CRD - see Kubernetes CRD documentation.
+      // This needs to be passed implicitly to the skuber API to enable it to process TestResource requests.
+      // The json paths in the Scale subresource must map to the replica fields in Spec and Status
+      // respectively above
+      implicit val testResourceDefinition = ResourceDefinition[TestResource](
+        group = "test.skuber.io",
+        version = "v1alpha1",
+        kind = "SkuberTest",
+        shortNames = List("test","tests"),  // not needed but handy if debugging the tests
+        subresources = Some(Subresources()
+            .withStatusSubresource // enable status subresource
+            .withScaleSubresource(ScaleSubresource(".spec.desiredReplicas",".status.actualReplicas")) // enable scale subresource
+        )
       )
-    )
 
-    val testCrd=CustomResourceDefinition[TestResource]
+      // the following implicit values enable the scale and status methods on the skuber API to be called for this type
+      // (these calls will be rejected unless the subresources are enabled on the CRD)
+      implicit val scaleSubEnabled=CustomResource.scalingMethodsEnabler[TestResource]
+      implicit val statusSubEnabled=CustomResource.statusMethodsEnabler[TestResource]
 
-    println(Json.toJson(testCrd))
+      // Construct an exportable Kubernetes CRD that mirrors the details in the matching implicit resource definition above -
+      // the test will create it on Kubernetes so that the subsequent test requests can be handled by the cluster
+      val crd=CustomResourceDefinition[TestResource]
+
+      // Convenience method for constructing custom resources of the required type from a name snd a spec
+      def apply(name: String, spec: Spec) = CustomResource[Spec,Status](spec).withName(name)
+    }
+
+    val initialDesiredReplicas=1
+
+    val modifiedDesiredReplicas=2
+    val modifiedActualReplicas=3
 
     behavior of "CustomResource"
 
     it should "create a crd" in { k8s =>
 
-      k8s.create(testCrd) map { c =>
-        assert(c.name == testCrd.name)
+      k8s.create(TestResource.crd) map { c =>
+        assert(c.name == TestResource.crd.name)
         assert(c.spec.defaultVersion == "v1alpha1")
         assert(c.spec.group == Some(("test.skuber.io")))
       }
     }
 
     it should "get the newly created crd" in { k8s =>
-      k8s.get[CustomResourceDefinition](testCrd.name) map { c =>
-        assert(c.name == testCrd.name)
+      k8s.get[CustomResourceDefinition](TestResource.crd.name) map { c =>
+        assert(c.name == TestResource.crd.name)
       }
     }
 
     it should "create a new custom resource defined by the crd" in { k8s =>
-      val testSpec=TestSpec(1)
-      val cr=CustomResource(testSpec).withName(testResourceName)
-      k8s.create(cr).map { testResource =>
+      val testSpec=TestResource.Spec(1)
+      val testResource=TestResource(testResourceName, testSpec)
+      k8s.create(testResource).map { testResource =>
         assert(testResource.name==testResourceName)
         assert(testResource.spec==testSpec)
       }
@@ -78,16 +130,32 @@ class CustomResourceSpec extends K8SFixture with Eventually with Matchers {
       }
     }
 
-    // Note: the following requires Custom Resources subresources to be enabled - on v1.10 this requires a feature gate
-    // to be enabled, from v1.11 it s enabled by default
-    it should "update the status on the custom resource" in { k8s =>
-      val status=TestStatus(1)
+    it should "scale the desired replicas on the spec of the custom resource" in { k8s =>
+      val updatedFut = for {
+        currentScale <- k8s.getScale[TestResource](testResourceName)
+        scaled <- k8s.updateScale[TestResource](testResourceName, currentScale.withSpecReplicas(modifiedDesiredReplicas))
+        updated <- k8s.get[TestResource](testResourceName)
+      } yield updated
+      updatedFut.map { updated =>
+        assert(updated.spec.desiredReplicas==modifiedDesiredReplicas)
+      }
+    }
+
+    it should "update the status on the custom resource with a modified actual replicas count" in { k8s =>
+      val status=TestResource.Status(modifiedActualReplicas)
       val updatedFut = for {
         testResource <- k8s.get[TestResource](testResourceName)
         updatedTestResource <- k8s.updateStatus(testResource.withStatus(status))
       } yield updatedTestResource
       updatedFut.map { updated =>
         updated.status shouldBe Some(status)
+      }
+    }
+
+    it should "return the modified desired and actual replica counts in response to a getScale request" in { k8s =>
+      k8s.getScale[TestResource](testResourceName).map { scale =>
+        assert(scale.spec.replicas == modifiedDesiredReplicas)
+        assert(scale.status.get.replicas == modifiedActualReplicas)
       }
     }
 
@@ -111,7 +179,7 @@ class CustomResourceSpec extends K8SFixture with Eventually with Matchers {
       import scala.collection.mutable.ListBuffer
 
       val testResourceName=java.util.UUID.randomUUID().toString
-      val testResource = CustomResource(TestSpec(1)).withName(testResourceName)
+      val testResource = TestResource(testResourceName, TestResource.Spec(1))
 
       val trackedEvents = ListBuffer.empty[WatchEvent[TestResource]]
       val trackEvents: Sink[WatchEvent[TestResource],_] = Sink.foreach { event =>
@@ -155,9 +223,9 @@ class CustomResourceSpec extends K8SFixture with Eventually with Matchers {
     }
 
     it should "delete the crd" in { k8s =>
-      k8s.delete[CustomResourceDefinition](testCrd.name)
+      k8s.delete[CustomResourceDefinition](TestResource.crd.name)
       eventually(timeout(200 seconds), interval(3 seconds)) {
-        val retrieveCrd= k8s.get[CustomResourceDefinition](testCrd.name)
+        val retrieveCrd= k8s.get[CustomResourceDefinition](TestResource.crd.name)
         val crdRetrieved=Await.ready(retrieveCrd, 2 seconds).value.get
         crdRetrieved match {
           case s: Success[_] => assert(false)

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -393,7 +393,7 @@ package object client {
      {
        modify(HttpMethods.PUT)(obj)
      }
-     
+
      def updateStatus[O <: ObjectResource](obj: O)(implicit
        fmt: Format[O],
        rd: ResourceDefinition[O],

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -393,6 +393,25 @@ package object client {
      {
        modify(HttpMethods.PUT)(obj)
      }
+     
+     def updateStatus[O <: ObjectResource](obj: O)(implicit
+       fmt: Format[O],
+       rd: ResourceDefinition[O],
+       lc: LoggingContext=RequestLoggingContext(),
+       statusEv: HasStatusSubresource[O]): Future[O] =
+     {
+       val statusSubresourcePath=s"${obj.name}/status"
+       modify(HttpMethods.PUT,obj,Some(statusSubresourcePath))
+     }
+
+     def getStatus[O <: ObjectResource](name: String)(implicit
+       fmt: Format[O],
+       rd: ResourceDefinition[O],
+       lc: LoggingContext=RequestLoggingContext(),
+       statusEv: HasStatusSubresource[O]): Future[O] =
+     {
+        _get[O](s"${name}/status")
+     }
 
      def updateStatus[O <: ObjectResource](obj: O)(implicit
        fmt: Format[O],

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -413,25 +413,6 @@ package object client {
         _get[O](s"${name}/status")
      }
 
-     def updateStatus[O <: ObjectResource](obj: O)(implicit
-       fmt: Format[O],
-       rd: ResourceDefinition[O],
-       lc: LoggingContext=RequestLoggingContext(),
-       statusEv: HasStatusSubresource[O]): Future[O] =
-     {
-       val statusSubresourcePath=s"${obj.name}/status"
-       modify(HttpMethods.PUT,obj,Some(statusSubresourcePath))
-     }
-
-     def getStatus[O <: ObjectResource](name: String)(implicit
-       fmt: Format[O],
-       rd: ResourceDefinition[O],
-       lc: LoggingContext=RequestLoggingContext(),
-       statusEv: HasStatusSubresource[O]): Future[O] =
-     {
-        _get[O](s"${name}/status")
-     }
-
      def getNamespaceNames(implicit lc: LoggingContext=RequestLoggingContext()): Future[List[String]] =
      {
        list[NamespaceList].map { namespaceList =>

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -615,6 +615,7 @@ package object client {
        makeRequestReturningObjectResource[Scale](req)
      }
 
+     @deprecated("use getScale followed by updateScale instead")
      def scale[O <: ObjectResource](objName: String, count: Int)(
        implicit rd: ResourceDefinition[O], sc: Scale.SubresourceSpec[O], lc:LoggingContext=RequestLoggingContext()): Future[Scale] =
      {
@@ -623,6 +624,12 @@ package object client {
          metadata = ObjectMeta(name = objName, namespace = namespaceName),
          spec = Scale.Spec(replicas = count)
        )
+       updateScale[O](objName, scale)
+     }
+
+     def updateScale[O <: ObjectResource](objName: String, scale: Scale)(
+      implicit rd: ResourceDefinition[O], sc: Scale.SubresourceSpec[O], lc:LoggingContext=RequestLoggingContext()): Future[Scale] =
+     {
        implicit val dispatcher=actorSystem.dispatcher
        val marshal = Marshal(scale)
        for {


### PR DESCRIPTION
- Extend custom resources integration tests to include  scale subresource handling
- Refactored implicit scale subresource handling to make it clearer and easier to use, and updated tests to reflect the changes
- Deprecated 'scale' method (which doesn't work with custom resources) in favour of doing a `getScale `followed by calling the new `updateScale` method.
