### PR TITLE
In-cluster configuration and docs

### DIFF
--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -853,7 +853,7 @@ package object client {
             }.getOrElse {
               // Try to get config from a running pod
               // if that is not set then use default kubeconfig location
-              Configuration.useRunningPod.orElse(
+              Configuration.inClusterConfig.orElse(
                 Configuration.parseKubeconfigFile()
               )
             }.get

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -4,7 +4,7 @@ Skuber supports both out-of-cluster and in-cluster configurations.
 Сonfiguration algorithm can be described as follows:
 
 Initailly Skuber tries out-of-cluster methods in sequence (stops on first successful):
- 1. __Cluster URL__: Read `SKUBER_URL` environment variable and use it as kubectl proxy url. If not set then:
+ 1. Read `SKUBER_URL` environment variable and use it as kubectl proxy url. If not set then:
  1. Read `SKUBER_CONFIG` environment variable and if is equal to:
     * `file`  - Skuber will read `~/.kube/config` and use it as configuration source
     * `proxy` - Skuber will assume that kubectl proxy running on `localhost:8080` and will use it as endpoint to cluster API 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,6 +1,19 @@
 ## Configuration
 
-By default the configuration Skuber uses to connect to the Kubernetes cluster depends on the setting of various environment variables as follows.
+Skuber supports both out-of-cluster and in-cluster configurations.
+Сonfiguration algorithm can be described as follows:
+
+Initailly Skuber tries out-of-cluster methods in sequence (stops on first successful):
+ 1. __Cluster URL__: Read `SKUBER_URL` environment variable and use it as kubectl proxy url. If not set then:
+ 1. Read `SKUBER_CONFIG` environment variable and if is equal to:
+    * `file`  - Skuber will read `~/.kube/config` and use it as configuration source
+    * `proxy` - Skuber will assume that kubectl proxy running on `localhost:8080` and will use it as endpoint to cluster API 
+    * Otherwise treats contents of `SKUBER_CONFIG` as a file path to kubeconfig file (use it if your kube config file is in custom location). If not present then:
+ 1. Read `KUBECONFIG` environment variable and use its contents as path to kubconfig file (similar to `SKUBER_CONFIG`)
+
+
+If all above fails Skuber tries [in-cluster configuration method](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)
+
 
 ### Cluster URL
 


### PR DESCRIPTION
Adresses #169 
Added some docs to clarify configuration flow.
Also refactored in-cluster configuration algorithm:
 * more ideomatic scala code style
 * use `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables to determine cluster API endpoint because according to [documentation](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service) using DNS endpoint creates a dependency on kube-dns cluster add-on (all official kuberntetes clients currently use env vars, and in case of using DNS endpoint the resolution of API port is somewhat ambiguous)