### PR TITLE
Upgrade scpec2 to fix #171

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
 val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.5"
-val specs2 = "org.specs2" %% "specs2-core" % "3.9.5"
+val specs2 = "org.specs2" %% "specs2-core" % "4.3.2"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4"
 
 val snakeYaml =  "org.yaml" % "snakeyaml" % "1.16"

--- a/client/src/test/scala/skuber/api/ListQueryParamSpec.scala
+++ b/client/src/test/scala/skuber/api/ListQueryParamSpec.scala
@@ -18,9 +18,8 @@ import LabelSelector.dsl._
  */
 class ListQueryParamSpec extends Specification {
 
-  type EE = ExecutionEnv
 
-  "LabelSelector string representations equate to the associated labelSelector query param values" >> { implicit ee: EE =>
+  "LabelSelector string representations equate to the associated labelSelector query param values" >> {
 
     LabelSelector("tier" is "database").toString mustEqual "tier=database"
     LabelSelector("tier" isNot "database").toString mustEqual "tier!=database"


### PR DESCRIPTION
Upgrade specs2-core to fix unpredictable class loader selection while running tests from sbt
Fixes #171