### PR TITLE
Refactored readme and ammonite quickstart

### DIFF
--- a/Quickstart.sc
+++ b/Quickstart.sc
@@ -1,0 +1,30 @@
+/* This is a quick start ammoninte script fot the impatient
+   Script assumes that you have a running kubernetes cluster or minikube running
+   and kube config file located in default location 
+
+   Cluster access configuration is parsed to `cfg` val
+   Client val is called `k8s`
+*/
+import $ivy.`io.skuber::skuber:2.0.9`, skuber._, skuber.json.format._
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import api.Configuration
+import scala.concurrent.Future
+import scala.util.{Success, Failure}
+import skuber.apps.v1.Deployment
+
+// Some standard Akka implicits that are required by the skuber v2 client API
+implicit val system = ActorSystem()
+implicit val materializer = ActorMaterializer()
+implicit val dispatcher = system.dispatcher
+
+val cfg: Configuration = api.Configuration.parseKubeconfigFile().get
+println("'cfg' <= configuration parsed")
+
+// Initialise skuber client
+val k8s = k8sInit(cfg)
+println("'k8s' <= client initialized")
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Build Status](https://travis-ci.org/doriordan/skuber.svg?branch=master)](https://travis-ci.org/doriordan/skuber)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.skuber/skuber_2.12/badge.svg)](http://search.maven.org/#search|ga|1|g:%22io.skuber%22a:%22skuber_2.12%22)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/doriordan/skuber/blob/master/LICENSE.txt)
@@ -19,33 +18,9 @@ Skuber is a Scala client library for [Kubernetes](http://kubernetes.io). It prov
 
 See the [programming guide](docs/GUIDE.md) for more details.
 
-## Quick Start
+## Example
 
-Make sure [prerequisites](#prerequisites) are met. There are couple of quick ways to get started with Skuber:
-
-### With [Ammonite-REPL](http://ammonite.io/#Ammonite-REPL) 
-
-Provides you with a configured client on startup. It is handy to use this for quick experiments. 
-- using bash
-    
-  ```bash
-  $ amm -p ./Quickstart.sc
-  ```
-
-- from inside ammonite-repl:
-  ```scala
-  import $file.`Quickstart`, Quickstart._
-  ```
-
-  ###### Just handy shortcut to import skuber inside ammonite-repl:
-
-  ```
-  import $ivy.`io.skuber::skuber:2.0.9`, skuber._, skuber.json.format._
-  ```
-
-### Copy-paste ready snippet
-
-  This example lists pods in `kube-system` namespace. It unsafely assumes that your kubeconfig file exists and kubernetes cluster is accessible:
+This example lists pods in `kube-system` namespace:
 
   ```scala
   import skuber._
@@ -58,20 +33,47 @@ Provides you with a configured client on startup. It is handy to use this for qu
   implicit val materializer = ActorMaterializer()
   implicit val dispatcher = system.dispatcher
 
-  val cfg: Configuration = Configuration.parseKubeconfigFile().get
-  val k8s = k8sInit(cfg)
+  val k8s = k8sInit()
   val listPodsRequest = k8s.listInNamespace[PodList]("kube-system")
   listPodsRequest.onComplete {
     case Success(pods) => pods.items.foreach { p => println(p.name) }
     case Failure(e) => throw(e)
   }
   ```
-  See more elaborate example [here](docs/Examples.md):
+
+  See more elaborate example [here](docs/Examples.md).
+
+## Quick Start
+
+Make sure [prerequisites](#prerequisites) are met. There are couple of quick ways to get started with Skuber:
+
+### With [Ammonite-REPL](http://ammonite.io/#Ammonite-REPL)
+
+Provides you with a configured client on startup. It is handy to use this for quick experiments.
+
+- using bash
+
+  ```bash
+  $ amm -p ./Quickstart.sc
+  ```
+
+- from inside ammonite-repl:
+
+  ```scala
+  import $file.`Quickstart`, Quickstart._
+  ```
+
+  > Just handy shortcut to import skuber inside ammonite-repl:
+
+  ```scala
+  import $ivy.`io.skuber::skuber:2.0.9`, skuber._, skuber.json.format._
+  ```
 
 ### Interactive with sbt
 
-  * Clone this repository.
-  * Tell Skuber to configure itself from the default Kubeconfig file (`$HOME/.kube/config`):
+- Clone this repository.
+
+- Tell Skuber to configure itself from the default Kubeconfig file (`$HOME/.kube/config`):
 
     ```bash
     export SKUBER_CONFIG=file
@@ -79,41 +81,38 @@ Provides you with a configured client on startup. It is handy to use this for qu
 
     Read more about Skuber configuration [here](docs/Configuration.md)
 
-  * Run `sbt` and try  one or more of the [examples](./examples/src/main/scala/skuber/examples) and then:
+- Run `sbt` and try  one or more of the [examples](./examples/src/main/scala/skuber/examples) and then:
 
-    ```bash
-    sbt:root> project examples
-    sbt:skuber-examples> run
+  ```bash
+  sbt:root> project examples
+  sbt:skuber-examples> run
 
-    Multiple main classes detected, select one to run:
+  Multiple main classes detected, select one to run:
 
-     [1] skuber.examples.customresources.CreateCRD
-     [2] skuber.examples.deployment.DeploymentExamples
-     [3] skuber.examples.fluent.FluentExamples
-     [4] skuber.examples.guestbook.Guestbook
-     [5] skuber.examples.ingress.NginxIngress
-     [6] skuber.examples.job.PrintPiJob
-     [7] skuber.examples.list.ListExamples
-     [8] skuber.examples.patch.PatchExamples
-     [9] skuber.examples.podlogs.PodLogExample
-     [10] skuber.examples.scale.ScaleExamples
-     [11] skuber.examples.watch.WatchExamples
+   [1] skuber.examples.customresources.CreateCRD
+   [2] skuber.examples.deployment.DeploymentExamples
+   [3] skuber.examples.fluent.FluentExamples
+   [4] skuber.examples.guestbook.Guestbook
+   [5] skuber.examples.ingress.NginxIngress
+   [6] skuber.examples.job.PrintPiJob
+   [7] skuber.examples.list.ListExamples
+   [8] skuber.examples.patch.PatchExamples
+   [9] skuber.examples.podlogs.PodLogExample
+   [10] skuber.examples.scale.ScaleExamples
+   [11] skuber.examples.watch.WatchExamples
 
-    Enter number:
-    ```
+  Enter number:
+  ```
 
 For other Kubernetes setups, see the [configuration guide](docs/Configuration.md) for details on how to tailor the configuration for your clusters security, namespace and connectivity requirements.
 
-
 ## Prerequisites
 
-* Java 8
-* Kubernetes cluster
+- Java 8
+- Kubernetes cluster
 
 A Kubernetes cluster is needed at runtime. For local development purposes, minikube is recommended.
 To get minikube follow the instructions [here](https://github.com/kubernetes/minikube)
-
-
 
 ## Release
 
@@ -136,7 +135,6 @@ If you have a Skuber client using release v1.x and want to move to the strategic
 ## Building
 
 Building the library from source is very straightforward. Simply run `sbt test`in the root directory of the project to build the library (and examples) and run the unit tests to verify the build.
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 [![Build Status](https://travis-ci.org/doriordan/skuber.svg?branch=master)](https://travis-ci.org/doriordan/skuber)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.skuber/skuber_2.12/badge.svg)](http://search.maven.org/#search|ga|1|g:%22io.skuber%22a:%22skuber_2.12%22)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/doriordan/skuber/blob/master/LICENSE.txt)
 
 # Skuber
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Provides you with a configured client on startup. It is handy to use this for qu
   import $file.`Quickstart`, Quickstart._
   ```
 
-  ##### Just handy shortcut to import skuber inside ammonite-repl:
+  ###### Just handy shortcut to import skuber inside ammonite-repl:
 
   ```
   import $ivy.`io.skuber::skuber:2.0.9`, skuber._, skuber.json.format._
@@ -44,7 +44,7 @@ Provides you with a configured client on startup. It is handy to use this for qu
 
 ### Copy-paste ready snippet
 
-  This example lists pods in `kube-system` namespace
+  This example lists pods in `kube-system` namespace. It unsafely assumes that your kubeconfig file exists and kubernetes cluster is accessible:
 
   ```scala
   import skuber._

--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 
 # Skuber
 
-
 Skuber is a Scala client library for [Kubernetes](http://kubernetes.io). It provides a fully featured, high-level and strongly typed Scala API for managing Kubernetes cluster resources (such as Pods, Services, Deployments, ReplicaSets, Ingresses  etc.) via the Kubernetes REST API server.
 
 ## Features
 
 - Comprehensive support for Kubernetes API model represented as Scala case classes
 - Support for core, extensions and other Kubernetes API groups
-- Full support for converting resources between the case class and standard JSON representations 
+- Full support for converting resources between the case class and standard JSON representations
 - Client API for creating, reading, updating, removing, listing and watching resources on a Kubernetes cluster
 - The API is asynchronous and strongly typed e.g. `k8s get[Deployment]("nginx")` returns a value of type `Future[Deployment]`
 - Fluent API for creating and updating specifications of Kubernetes resources
@@ -23,45 +22,70 @@ See the [programming guide](docs/GUIDE.md) for more details.
 
 Make sure [prerequisites](#prerequisites) are met. There are couple of quick ways to get started with Skuber:
 
-- With [Ammonite-REPL](http://ammonite.io/#Ammonite-REPL) for quick experiments:
-    
-    using bash:
-    ```bash
-    $ amm -p ./Quickstart.sc
-    ```
-    
-    from inside ammonite-repl:
-    ```scala
-    import $file.`Quickstart`, Quickstart._
-    ```
-      
-    Provides you with a configured client on startup. See more [elaborate example](docs/Examples.md)  
-    
-    Just handy shortcut to import skuber inside ammonite-repl: 
-    
-    ```import $ivy.`io.skuber::skuber:2.0.9`, skuber._, skuber.json.format._```
-   
+### With [Ammonite-REPL](http://ammonite.io/#Ammonite-REPL) 
 
-- Interactive with sbt 
+Provides you with a configured client on startup. It is handy to use this for quick experiments. 
+- using bash
     
-    Clone this repository.   
-    Tell Skuber to configure itself from the default Kubeconfig file (`$HOME/.kube/config`):
-    
+  ```bash
+  $ amm -p ./Quickstart.sc
+  ```
+
+- from inside ammonite-repl:
+  ```scala
+  import $file.`Quickstart`, Quickstart._
+  ```
+
+  ##### Just handy shortcut to import skuber inside ammonite-repl:
+
+  ```
+  import $ivy.`io.skuber::skuber:2.0.9`, skuber._, skuber.json.format._
+  ```
+
+### Copy-paste ready snippet
+
+  This example lists pods in `kube-system` namespace
+
+  ```scala
+  import skuber._
+  import skuber.json.format._
+  import akka.actor.ActorSystem
+  import akka.stream.ActorMaterializer
+  import scala.util.{Success, Failure}
+
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+  implicit val dispatcher = system.dispatcher
+
+  val cfg: Configuration = Configuration.parseKubeconfigFile().get
+  val k8s = k8sInit(cfg)
+  val listPodsRequest = k8s.listInNamespace[PodList]("kube-system")
+  listPodsRequest.onComplete {
+    case Success(pods) => pods.items.foreach { p => println(p.name) }
+    case Failure(e) => throw(e)
+  }
+  ```
+  See more elaborate example [here](docs/Examples.md):
+
+### Interactive with sbt
+
+  * Clone this repository.
+  * Tell Skuber to configure itself from the default Kubeconfig file (`$HOME/.kube/config`):
 
     ```bash
     export SKUBER_CONFIG=file
     ```
-     
-    Read more about Skuber configuration [here](docs/Configuration.md) 
-    
-    Run `sbt` and try  one or more of the [examples](./examples/src/main/scala/skuber/examples) and then:
+
+    Read more about Skuber configuration [here](docs/Configuration.md)
+
+  * Run `sbt` and try  one or more of the [examples](./examples/src/main/scala/skuber/examples) and then:
 
     ```bash
     sbt:root> project examples
     sbt:skuber-examples> run
-    
+
     Multiple main classes detected, select one to run:
-    
+
      [1] skuber.examples.customresources.CreateCRD
      [2] skuber.examples.deployment.DeploymentExamples
      [3] skuber.examples.fluent.FluentExamples
@@ -73,7 +97,7 @@ Make sure [prerequisites](#prerequisites) are met. There are couple of quick way
      [9] skuber.examples.podlogs.PodLogExample
      [10] skuber.examples.scale.ScaleExamples
      [11] skuber.examples.watch.WatchExamples
-    
+
     Enter number:
     ```
 
@@ -82,11 +106,11 @@ For other Kubernetes setups, see the [configuration guide](docs/Configuration.md
 
 ## Prerequisites
 
-* Java 8 
+* Java 8
 * Kubernetes cluster
 
 A Kubernetes cluster is needed at runtime. For local development purposes, minikube is recommended.
-To get minikube follow the instructions [here](https://github.com/kubernetes/minikube) 
+To get minikube follow the instructions [here](https://github.com/kubernetes/minikube)
 
 
 
@@ -95,7 +119,7 @@ To get minikube follow the instructions [here](https://github.com/kubernetes/min
 You can use the latest release (for Scala 2.11 or 2.12) by adding to your build:
 
 ```sbt
-libraryDependencies += "io.skuber" %% "skuber" % "2.0.9"    
+libraryDependencies += "io.skuber" %% "skuber" % "2.0.9"
 ```
 
 Meanwhile users of skuber v1 can continue to use the latest (and possibly final, with exception of important fixes) v1.x release, which is available only on Scala 2.11:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 
+[![Build Status](https://travis-ci.org/doriordan/skuber.svg?branch=master)](https://travis-ci.org/doriordan/skuber)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.skuber/skuber_2.12/badge.svg)](http://search.maven.org/#search|ga|1|g:%22io.skuber%22a:%22skuber_2.12%22)
+
 # Skuber
+
 
 Skuber is a Scala client library for [Kubernetes](http://kubernetes.io). It provides a fully featured, high-level and strongly typed Scala API for managing Kubernetes cluster resources (such as Pods, Services, Deployments, ReplicaSets, Ingresses  etc.) via the Kubernetes REST API server.
 
@@ -11,61 +15,80 @@ Skuber is a Scala client library for [Kubernetes](http://kubernetes.io). It prov
 - Client API for creating, reading, updating, removing, listing and watching resources on a Kubernetes cluster
 - The API is asynchronous and strongly typed e.g. `k8s get[Deployment]("nginx")` returns a value of type `Future[Deployment]`
 - Fluent API for creating and updating specifications of Kubernetes resources
-- Uses standard `kubeconfig` files for configuration - see the [Configuration guide](docs/Configuration.md) for details
+- Uses standard `kubeconfig` files for configuration - see the [configuration guide](docs/Configuration.md) for details
 
 See the [programming guide](docs/GUIDE.md) for more details.
 
-## Example Usage
+## Quick Start
 
-This example creates a nginx service (accessed via port 30001 on each Kubernetes cluster node) that is backed by a deployment of five nginx replicas.
+Make sure [prerequisites](#prerequisites) are met. There are couple of quick ways to get started with Skuber:
 
-```scala
-import skuber._
-import skuber.json.format._
-import skuber.apps.v1.Deployment
-import LabelSelector.dsl._
+- With [Ammonite-REPL](http://ammonite.io/#Ammonite-REPL) for quick experiments:
+    
+    using bash:
+    ```bash
+    $ amm -p ./Quickstart.sc
+    ```
+    
+    from inside ammonite-repl:
+    ```scala
+    import $file.`Quickstart`, Quickstart._
+    ```
+      
+    Provides you with a configured client on startup. See more [elaborate example](docs/Examples.md)  
+    
+    Just handy shortcut to import skuber inside ammonite-repl: 
+    
+    ```import $ivy.`io.skuber::skuber:2.0.9`, skuber._, skuber.json.format._```
+   
 
-val nginxSelector  = "app" is "nginx" 
-val nginxContainer = Container(name = "nginx", image = "nginx").exposePort(80) 
-val nginxTemplate = Pod.Template.Spec.named("nginx").addContainer(nginxContainer).addLabel("app" -> "nginx")
-val nginxDeployment = Deployment(name)
-    .withReplicas(5)
-    .withTemplate(nginxTemplate)
-    .withLabelSelector(nginxSelector)
-val nginxService = Service("nginx")
-    .withSelector("app" -> "nginx")
-    .exposeOnNodePort(30001 -> 80) 
+- Interactive with sbt 
+    
+    Clone this repository.   
+    Tell Skuber to configure itself from the default Kubeconfig file (`$HOME/.kube/config`):
+    
 
-// Some standard Akka implicits that are required by the skuber v2 client API
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-implicit val system = ActorSystem()
-implicit val materializer = ActorMaterializer()
-implicit val dispatcher = system.dispatcher
+    ```bash
+    export SKUBER_CONFIG=file
+    ```
+     
+    Read more about Skuber configuration [here](docs/Configuration.md) 
+    
+    Run `sbt` and try  one or more of the [examples](./examples/src/main/scala/skuber/examples) and then:
 
-// Initialise skuber client
-val k8s = k8sInit
+    ```bash
+    sbt:root> project examples
+    sbt:skuber-examples> run
+    
+    Multiple main classes detected, select one to run:
+    
+     [1] skuber.examples.customresources.CreateCRD
+     [2] skuber.examples.deployment.DeploymentExamples
+     [3] skuber.examples.fluent.FluentExamples
+     [4] skuber.examples.guestbook.Guestbook
+     [5] skuber.examples.ingress.NginxIngress
+     [6] skuber.examples.job.PrintPiJob
+     [7] skuber.examples.list.ListExamples
+     [8] skuber.examples.patch.PatchExamples
+     [9] skuber.examples.podlogs.PodLogExample
+     [10] skuber.examples.scale.ScaleExamples
+     [11] skuber.examples.watch.WatchExamples
+    
+    Enter number:
+    ```
 
-// Create the service and the deployment on the Kubernetes cluster
-val createOnK8s = for {
-  svc <- k8s create nginxService
-  dep  <- k8s create nginxDeployment
-} yield (dep,svc)
+For other Kubernetes setups, see the [configuration guide](docs/Configuration.md) for details on how to tailor the configuration for your clusters security, namespace and connectivity requirements.
 
-createOnK8s onComplete {
-  case Success(_) => System.out.println("Successfully created nginx deployment & service on Kubernetes cluster")
-  case Failure(ex) => System.err.println("Encountered exception trying to create resources on Kubernetes cluster: " + ex)
-}
-
-k8s.close // this prevents any more requests being sent by the client
-system.terminate // this closes the connection resources etc.
-```
 
 ## Prerequisites
 
-A Kubernetes cluster is needed at runtime. For local development purposes, minikube is recommended.
+* Java 8 
+* Kubernetes cluster
 
-You need Java 8 to run Skuber.
+A Kubernetes cluster is needed at runtime. For local development purposes, minikube is recommended.
+To get minikube follow the instructions [here](https://github.com/kubernetes/minikube) 
+
+
 
 ## Release
 
@@ -88,44 +111,6 @@ If you have a Skuber client using release v1.x and want to move to the strategic
 ## Building
 
 Building the library from source is very straightforward. Simply run `sbt test`in the root directory of the project to build the library (and examples) and run the unit tests to verify the build.
-
-## Quick Start
-
-The quickest way to get started with Skuber:
-
-- If you don't already have Kubernetes installed, then follow the instructions [here](https://github.com/kubernetes/minikube) to install minikube, which is now the recommended way to run Kubernetes locally.
-
-- Ensure Skuber configures itself from the default Kubeconfig file (`$HOME/.kube/config`) : 
-
-    ```bash
-    export SKUBER_CONFIG=file
-    ``` 
-
-- Try one or more of the examples: if you have cloned this repository run `sbt` in the top-level directory to start sbt in interactive mode and then:
-
-```bash
-sbt:root> project examples
-sbt:skuber-examples> run
-
-Multiple main classes detected, select one to run:
-
- [1] skuber.examples.customresources.CreateCRD
- [2] skuber.examples.deployment.DeploymentExamples
- [3] skuber.examples.fluent.FluentExamples
- [4] skuber.examples.guestbook.Guestbook
- [5] skuber.examples.ingress.NginxIngress
- [6] skuber.examples.job.PrintPiJob
- [7] skuber.examples.list.ListExamples
- [8] skuber.examples.patch.PatchExamples
- [9] skuber.examples.podlogs.PodLogExample
- [10] skuber.examples.scale.ScaleExamples
- [11] skuber.examples.watch.WatchExamples
-
-Enter number:
-```
-
-For other Kubernetes setups, see the [Configuration guide](docs/Configuration.md) for details on how to tailor the configuration for your clusters security, namespace and connectivity requirements.
-
 
 
 ## License

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,0 +1,99 @@
+# Skuber usage examples
+
+
+##### Basic imports:  
+
+```scala
+import skuber._
+import skuber.json.format._
+
+
+// Some standard Akka implicits that are required by the skuber v2 client API
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+implicit val system = ActorSystem()
+implicit val materializer = ActorMaterializer()
+implicit val dispatcher = system.dispatcher
+```
+
+##### Populate cluster access configuration and initialize client
+
+You can configure cluster in [many different ways](Configuration.md). This example
+directly calls method that reads kubeconfig file at default location.
+Check [kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#before-you-begin) if you don't know what is kubeconfig or where to look for it.
+```scala
+import api.Configuration
+
+// unsafely assumes that Success is returned.
+val cfg: Configuration = Configuration.parseKubeconfigFile().get
+val k8s = k8sInit(cfg)
+```
+
+
+##### List pods example
+
+Here we use `k8s` client to get all pods in `kube-system` namespace:
+```scala
+// 
+import scala.util.{Success, Failure}
+val listPodsRequest = k8s.listInNamespace[PodList]("kube-system")
+listPodsRequest.onComplete {
+  case Success(pods) => pods.items.foreach { p => println(p.name) }
+  case Failure(e) => throw(e)
+}
+```
+
+##### Create deployment
+
+This example creates a nginx service (accessed via port 30001 on each Kubernetes cluster node) that is backed by a deployment of five nginx replicas.
+ Requires defining selector, container description, pod spec, deployment and service:  
+
+```scala
+// Define selector 
+import LabelSelector.dsl._
+val nginxSelector  = "app" is "nginx"
+
+// Define nginx container
+val nginxContainer = Container(name = "nginx", image = "nginx")
+  .exposePort(80)
+
+// Define nginx pod template spec
+val nginxTemplate = Pod.Template.Spec
+  .named("nginx")
+  .addContainer(nginxContainer)
+  .addLabel("app" -> "nginx")
+
+// Define nginx deployment 
+import skuber.apps.v1.Deployment
+val nginxDeployment = Deployment("nginx")
+  .withReplicas(5)
+  .withTemplate(nginxTemplate)
+  .withLabelSelector(nginxSelector)
+
+// Define nginx service
+val nginxService = Service("nginx")
+  .withSelector("app" -> "nginx")
+  .exposeOnNodePort(30001 -> 80)
+
+// Create the service and the deployment on the Kubernetes cluster
+val createOnK8s = for {
+  svc  <- k8s create nginxService
+  dep  <- k8s create nginxDeployment
+} yield (dep,svc)
+
+createOnK8s.onComplete {
+  case Success(_)  => println("Successfully created nginx deployment & service on Kubernetes cluster")
+  case Failure(ex) => throw (new Exception("Encountered exception trying to create resources on Kubernetes cluster: ", ex))
+}
+```
+
+##### Safely shutdown the client 
+```scala
+// Close client.
+// This prevents any more requests being sent by the client.
+k8s.close 
+
+// this closes the connection resources etc.
+system.terminate 
+```

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,7 +1,6 @@
 # Skuber usage examples
 
-
-##### Basic imports:  
+## Basic imports
 
 ```scala
 import skuber._
@@ -17,25 +16,25 @@ implicit val materializer = ActorMaterializer()
 implicit val dispatcher = system.dispatcher
 ```
 
-##### Populate cluster access configuration and initialize client
+## Populate cluster access configuration and initialize client
 
 You can configure cluster in [many different ways](Configuration.md). This example
 directly calls method that reads kubeconfig file at default location.
 Check [kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#before-you-begin) if you don't know what is kubeconfig or where to look for it.
+
 ```scala
 import api.Configuration
 
-// unsafely assumes that Success is returned.
+// assumes that Success is returned.
 val cfg: Configuration = Configuration.parseKubeconfigFile().get
 val k8s = k8sInit(cfg)
 ```
 
-
-##### List pods example
+## List pods example
 
 Here we use `k8s` client to get all pods in `kube-system` namespace:
+
 ```scala
-// 
 import scala.util.{Success, Failure}
 val listPodsRequest = k8s.listInNamespace[PodList]("kube-system")
 listPodsRequest.onComplete {
@@ -44,13 +43,13 @@ listPodsRequest.onComplete {
 }
 ```
 
-##### Create deployment
+## Create deployment
 
 This example creates a nginx service (accessed via port 30001 on each Kubernetes cluster node) that is backed by a deployment of five nginx replicas.
- Requires defining selector, container description, pod spec, deployment and service:  
+ Requires defining selector, container description, pod spec, deployment and service:
 
 ```scala
-// Define selector 
+// Define selector
 import LabelSelector.dsl._
 val nginxSelector  = "app" is "nginx"
 
@@ -64,7 +63,7 @@ val nginxTemplate = Pod.Template.Spec
   .addContainer(nginxContainer)
   .addLabel("app" -> "nginx")
 
-// Define nginx deployment 
+// Define nginx deployment
 import skuber.apps.v1.Deployment
 val nginxDeployment = Deployment("nginx")
   .withReplicas(5)
@@ -88,12 +87,13 @@ createOnK8s.onComplete {
 }
 ```
 
-##### Safely shutdown the client 
+## Safely shutdown the client
+
 ```scala
 // Close client.
 // This prevents any more requests being sent by the client.
-k8s.close 
+k8s.close
 
 // this closes the connection resources etc.
-system.terminate 
+system.terminate
 ```


### PR DESCRIPTION
Some documentation improvements:
* added Travis-CI badge
* added Maven Central badge
* Quick start section moved closer to the beginning
* Added [Ammonite-REPL](http://ammonite.io/#Ammonite-REPL) script for quick experimentations
* More involved examples moved to separate file `docs/Examples.md`

You can quickly preview how readme looks in [my fork](https://github.com/ngortheone/skuber/tree/quickstart)