### PR TITLE
Change Container.Image.sizeBytes type from Option[Int] to Option[Long]

### DIFF
--- a/client/src/main/scala/skuber/Container.scala
+++ b/client/src/main/scala/skuber/Container.scala
@@ -171,6 +171,6 @@ object Container {
 
   case class Image(
     names: List[String] = Nil,
-    sizeBytes: Option[Int] = None
+    sizeBytes: Option[Long] = None
   )
 }    

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -666,7 +666,7 @@ package object format {
 
   implicit val cntnrImageFmt: Format[Container.Image] = (
     (JsPath \ "names").formatMaybeEmptyList[String] and
-    (JsPath \ "sizeBytes").formatNullable[Int]
+    (JsPath \ "sizeBytes").formatNullable[Long]
   )(Container.Image.apply _, unlift(Container.Image.unapply))
 
   implicit val podStatusCondFormat : Format[Pod.Condition] = (

--- a/client/src/test/resources/exampleNode.json
+++ b/client/src/test/resources/exampleNode.json
@@ -95,7 +95,7 @@
           "nginx@sha256:2f68b99bc0d6d25d0c56876b924ec20418544ff28e1fb89a4c27679a40da811b",
           "nginx:1.9.1"
         ],
-        "sizeBytes": 132835913
+        "sizeBytes": 13283591300
       },
       {
         "names": [


### PR DESCRIPTION
This avoids integer overflow errors in JSON parsing