### PR TITLE
Support pod exec

### DIFF
--- a/client/src/it/scala/skuber/ExecSpec.scala
+++ b/client/src/it/scala/skuber/ExecSpec.scala
@@ -1,0 +1,116 @@
+package skuber
+
+import akka.Done
+import akka.stream.scaladsl.{Sink, Source}
+import org.scalatest.{BeforeAndAfterAll, Matchers}
+import org.scalatest.concurrent.Eventually
+import skuber.json.format._
+
+import scala.concurrent.duration._
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, Promise}
+
+
+class ExecSpec extends K8SFixture with Eventually with Matchers with BeforeAndAfterAll {
+  val nginxPodName: String = java.util.UUID.randomUUID().toString
+
+  behavior of "Exec"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val k8s = k8sInit
+    Await.result(k8s.create(getNginxPod(nginxPodName, "1.7.9")), 3 second)
+    // Let the pod running
+    Thread.sleep(3000)
+    k8s.close
+  }
+
+  override def afterAll(): Unit = {
+    val k8s = k8sInit
+    Await.result(k8s.delete[Pod](nginxPodName), 3 second)
+    Thread.sleep(3000)
+    k8s.close
+
+    super.afterAll()
+  }
+
+  it should "execute a command in the running pod" in { k8s =>
+    var output = ""
+    val stdout: Sink[String, Future[Done]] = Sink.foreach(output += _)
+    var errorOutput = ""
+    val stderr: Sink[String, Future[Done]] = Sink.foreach(errorOutput += _)
+    k8s.exec(nginxPodName, Seq("whoami"), maybeStdout = Some(stdout), maybeStderr = Some(stderr), maybeClose = Some(closeAfter(1 second))).map { _ =>
+      assert(output == "root\n")
+      assert(errorOutput == "")
+    }
+  }
+
+  it should "execute a command in the specified container of the running pod" in { k8s =>
+    var output = ""
+    val stdout: Sink[String, Future[Done]] = Sink.foreach(output += _)
+    var errorOutput = ""
+    val stderr: Sink[String, Future[Done]] = Sink.foreach(errorOutput += _)
+    k8s.exec(nginxPodName, Seq("whoami"), maybeContainerName = Some("nginx"),
+      maybeStdout = Some(stdout), maybeStderr = Some(stderr), maybeClose = Some(closeAfter(1 second))).map { _ =>
+      assert(output == "root\n")
+      assert(errorOutput == "")
+    }
+  }
+
+  it should "execute a command that outputs to stderr in the running pod" in { k8s =>
+    var output = ""
+    val stdout: Sink[String, Future[Done]] = Sink.foreach(output += _)
+    var errorOutput = ""
+    val stderr: Sink[String, Future[Done]] = Sink.foreach(errorOutput += _)
+    k8s.exec(nginxPodName, Seq("sh", "-c", "whoami >&2"),
+      maybeStdout = Some(stdout), maybeStderr = Some(stderr), maybeClose = Some(closeAfter(1 second))).map { _ =>
+      assert(output == "")
+      assert(errorOutput == "root\n")
+    }
+  }
+
+  it should "execute a command in an interactive shell of the running pod" in { k8s =>
+    val stdin = Source.single("whoami\n")
+    var output = ""
+    val stdout: Sink[String, Future[Done]] = Sink.foreach(output += _)
+    var errorOutput = ""
+    val stderr: Sink[String, Future[Done]] = Sink.foreach(errorOutput += _)
+    k8s.exec(nginxPodName, Seq("sh"), maybeStdin = Some(stdin),
+      maybeStdout = Some(stdout), maybeStderr = Some(stderr), tty = true, maybeClose = Some(closeAfter(1 second))).map { _ =>
+      assert(output == "# whoami\r\nroot\r\n# ")
+      assert(errorOutput == "")
+    }
+  }
+
+  it should "throw an exception without stdin, stdout nor stderr in the running pod" in { k8s =>
+    k8s.exec(nginxPodName, Seq("whoami")).failed.map {
+      case e: K8SException =>
+        assert(e.status.message == Some("Connection failed with status 400 Bad Request"))
+    }
+  }
+
+  it should "throw an exception against an unexisting pod" in { k8s =>
+    k8s.exec(nginxPodName + "x", Seq("whoami")).failed.map {
+      case e: K8SException =>
+        assert(e.status.message == Some("Connection failed with status 404 Not Found"))
+    }
+  }
+
+  def closeAfter(duration: Duration) = {
+    val promise = Promise[Unit]()
+    Future {
+      Thread.sleep(duration.toMillis)
+      promise.success(())
+    }
+    promise
+  }
+
+  def getNginxContainer(version: String): Container = Container(name = "nginx", image = "nginx:" + version).exposePort(80)
+
+  def getNginxPod(name: String, version: String): Pod = {
+    val nginxContainer = getNginxContainer(version)
+    val nginxPodSpec = Pod.Spec(containers = List((nginxContainer)))
+    Pod.named(nginxPodName).copy(spec = Some(nginxPodSpec))
+  }
+}

--- a/client/src/it/scala/skuber/ExecSpec.scala
+++ b/client/src/it/scala/skuber/ExecSpec.scala
@@ -86,14 +86,14 @@ class ExecSpec extends K8SFixture with Eventually with Matchers with BeforeAndAf
   it should "throw an exception without stdin, stdout nor stderr in the running pod" in { k8s =>
     k8s.exec(nginxPodName, Seq("whoami")).failed.map {
       case e: K8SException =>
-        assert(e.status.message == Some("Connection failed with status 400 Bad Request"))
+        assert(e.status.code == Some(400))
     }
   }
 
   it should "throw an exception against an unexisting pod" in { k8s =>
     k8s.exec(nginxPodName + "x", Seq("whoami")).failed.map {
       case e: K8SException =>
-        assert(e.status.message == Some("Connection failed with status 404 Not Found"))
+        assert(e.status.code == Some(404))
     }
   }
 

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -779,7 +779,9 @@ package object client {
            Done
          } else {
            val message = upgrade.response.entity.toStrict(1000.millis).map(_.data.utf8String)
-           throw new K8SException(Status(message = Some(s"Connection failed with status ${upgrade.response.status}"), details = Some(message)))
+           throw new K8SException(Status(message =
+             Some(s"Connection failed with status ${upgrade.response.status}"),
+             details = Some(message), code = Some(upgrade.response.status.intValue())))
          }
        }
 

--- a/client/src/main/scala/skuber/api/security/HTTPRequestAuth.scala
+++ b/client/src/main/scala/skuber/api/security/HTTPRequestAuth.scala
@@ -1,6 +1,6 @@
 package skuber.api.security
 
-import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
 import skuber.api.client._
 
@@ -10,10 +10,18 @@ import skuber.api.client._
 object HTTPRequestAuth {
   
   def addAuth(request: HttpRequest, auth: AuthInfo) : HttpRequest = {
+    getAuthHeaders(auth).foreach { header =>
+      // Add headers one by one because `addHeaders()` doesn't convert the instance type
+      request.addHeader(header)
+    }
+    request
+  }
+
+  def getAuthHeaders(auth: AuthInfo) : Seq[HttpHeader] = {
     auth match {
-      case NoAuth | _: CertAuth => request
-      case BasicAuth(user, password) => request.addHeader(Authorization(BasicHttpCredentials(user,password)))
-      case auth: AccessTokenAuth => request.addHeader(Authorization(OAuth2BearerToken(auth.accessToken)))
+      case NoAuth | _: CertAuth => Seq()
+      case BasicAuth(user, password) => Seq(Authorization(BasicHttpCredentials(user,password)))
+      case auth: AccessTokenAuth => Seq(Authorization(OAuth2BearerToken(auth.accessToken)))
     }
   }   
 }

--- a/examples/src/main/scala/skuber/examples/exec/ExecExamples.scala
+++ b/examples/src/main/scala/skuber/examples/exec/ExecExamples.scala
@@ -1,0 +1,87 @@
+package skuber.examples.exec
+
+import akka.{Done, NotUsed}
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import skuber._
+
+import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.duration.Duration.Inf
+import skuber.json.format._
+
+object ExecExamples extends App {
+
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+  implicit val dispatcher = system.dispatcher
+
+  val k8s = k8sInit
+  k8s.logConfig
+
+  println("Executing commands in pods ==>")
+
+  val podName = "sleep"
+  val containerName = "sleep"
+  val sleepContainer = Container(name = containerName, image = "busybox", command = List("sh", "-c", "trap exit TERM; sleep 99999 & wait"))
+  val sleepPod = Pod(podName, Pod.Spec().addContainer(sleepContainer))
+
+  val terminalReady: Promise[Unit] = Promise()
+
+  // Just print stdout and signal when the terminal gets ready
+  val sink: Sink[String, Future[Done]] = Sink.foreach {
+    case s =>
+      print(s)
+      if (s.startsWith("/ #")) {
+        terminalReady.success(())
+      }
+  }
+
+  // Execute `ps aux` when the terminal gets ready
+  val source: Source[String, NotUsed] = Source.fromFuture(terminalReady.future.map { _ =>
+    "ps aux\n"
+  })
+
+  // Wait for a while to ensure outputs
+  def close: Promise[Unit] = {
+    val promise = Promise[Unit]()
+    Future {
+      Thread.sleep(1000)
+      promise.success(())
+    }
+    promise
+  }
+
+  val fut = for {
+    // Create the sleep pod if not present
+    _ <- k8s.getOption[Pod](podName).flatMap {
+      case Some(pod) => Future.successful()
+      case None =>
+        k8s.create(sleepPod).map { _ =>
+          Thread.sleep(3000)
+        }
+    }
+    // Simulate kubectl exec
+    _ <- {
+      println("`kubectl exec ps aux`")
+      k8s.exec(podName, Seq("ps", "aux"), maybeStdout = Some(sink), maybeClose = Some(close))
+    }
+    // Simulate kubectl exec -it
+    _ <- {
+      println("`kubectl -it exec sh` -> `ps aux`")
+      k8s.exec(podName, Seq("sh"), maybeStdout = Some(sink), maybeStdin = Some(source), tty = true, maybeClose = Some(close))
+    }
+  } yield ()
+
+  // Clean up
+  fut.onComplete { _ =>
+    println("\nFinishing up")
+    k8s.delete[Pod]("sleep")
+    k8s.close
+    system.terminate().foreach { f =>
+      System.exit(0)
+    }
+  }
+
+  Await.result(fut, Inf)
+}


### PR DESCRIPTION
This is the pull request of pod exec feature which hasn't implemented yet. It acts almost the same as `kubectl` and fully uses akka-http and akka-stream way to interact with pods.

I'd like to use this package for my project for Kubernetes but need to execute a command on running pods, so could you please consider merging this change?