### PR TITLE
Fix #202

### DIFF
--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -37,7 +37,7 @@ package object skuber {
   case class ObjectMeta(
     name: String = emptyS,
     generateName: String = emptyS,
-    namespace: String = "default",
+    namespace: String = emptyS,
     uid: String = emptyS,
     selfLink: String = emptyS,
     resourceVersion: String = emptyS,


### PR DESCRIPTION
Fixes #202 - new metadata should not contain explicitly set namespace, or at least namespace should an empty string. Tested with integration tests `PodSpec`