### PR TITLE
Add delete collection methods

### DIFF
--- a/client/src/it/scala/skuber/PodSpec.scala
+++ b/client/src/it/scala/skuber/PodSpec.scala
@@ -17,7 +17,7 @@ class PodSpec extends K8SFixture with Eventually with Matchers with BeforeAndAft
     val k8s = k8sInit
     val requirements = defaultLabels.toSeq.map { case (k, v) => LabelSelector.IsEqualRequirement(k, v) }
     val labelSelector = LabelSelector(requirements: _*)
-    Await.result(k8s.deleteCollectionSelected[PodList](labelSelector), 5 seconds)
+    Await.result(k8s.deleteAllSelected[PodList](labelSelector), 5 seconds)
   }
 
   behavior of "Pod"
@@ -81,7 +81,7 @@ class PodSpec extends K8SFixture with Eventually with Matchers with BeforeAndAft
     for {
       _ <- k8s.create(getNginxPod(nginxPodName + "-foo", "1.7.9", labels = Map("foo" -> "1")))
       _ <- k8s.create(getNginxPod(nginxPodName + "-bar", "1.7.9", labels = Map("bar" -> "2")))
-      _ <- k8s.deleteCollectionSelected[PodList](LabelSelector(LabelSelector.ExistsRequirement("foo")))
+      _ <- k8s.deleteAllSelected[PodList](LabelSelector(LabelSelector.ExistsRequirement("foo")))
     } yield eventually(timeout(100 seconds), interval(3 seconds)) {
       val retrievePods = k8s.list[PodList]()
       val podsRetrieved = Await.result(retrievePods, 2 seconds)

--- a/client/src/it/scala/skuber/PodSpec.scala
+++ b/client/src/it/scala/skuber/PodSpec.scala
@@ -1,21 +1,24 @@
 package skuber
 
-import org.scalatest.Matchers
+import org.scalatest.{BeforeAndAfterAll, Matchers}
 import org.scalatest.concurrent.Eventually
 import skuber.json.format._
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
-import akka.event.Logging
-import akka.stream.scaladsl._
-import akka.util.ByteString
 
-import scala.concurrent.Future
-
-class PodSpec extends K8SFixture with Eventually with Matchers {
+class PodSpec extends K8SFixture with Eventually with Matchers with BeforeAndAfterAll {
   val nginxPodName: String = java.util.UUID.randomUUID().toString
+  val defaultLabels = Map("app" -> this.suiteName)
+
+  override def afterAll() = {
+    val k8s = k8sInit
+    val requirements = defaultLabels.toSeq.map { case (k, v) => LabelSelector.IsEqualRequirement(k, v) }
+    val labelSelector = LabelSelector(requirements: _*)
+    Await.result(k8s.deleteCollectionSelected[PodList](labelSelector), 5 seconds)
+  }
 
   behavior of "Pod"
 
@@ -33,24 +36,24 @@ class PodSpec extends K8SFixture with Eventually with Matchers {
 
   it should "check for newly created pod and container to be ready" in { k8s =>
     eventually(timeout(100 seconds), interval(3 seconds)) {
-      val retrievePod=k8s.get[Pod](nginxPodName)
-      val podRetrieved=Await.ready(retrievePod, 2 seconds).value.get
-      val podStatus=podRetrieved.get.status.get
+      val retrievePod = k8s.get[Pod](nginxPodName)
+      val podRetrieved = Await.ready(retrievePod, 2 seconds).value.get
+      val podStatus = podRetrieved.get.status.get
       val nginxContainerStatus = podStatus.containerStatuses(0)
       podStatus.phase should contain(Pod.Phase.Running)
-      nginxContainerStatus.name should be("nginx")
+      nginxContainerStatus.name should be(nginxPodName)
       nginxContainerStatus.state.get shouldBe a[Container.Running]
-      val isUnschedulable=podStatus.conditions.exists { c =>
-        c._type=="PodScheduled" && c.status=="False" && c.reason==Some("Unschedulable")
+      val isUnschedulable = podStatus.conditions.exists { c =>
+        c._type == "PodScheduled" && c.status == "False" && c.reason == Some("Unschedulable")
       }
-      val isScheduled=podStatus.conditions.exists { c =>
-        c._type=="PodScheduled" && c.status=="True"
+      val isScheduled = podStatus.conditions.exists { c =>
+        c._type == "PodScheduled" && c.status == "True"
       }
-      val isInitialised=podStatus.conditions.exists { c =>
-        c._type=="Initialized" && c.status=="True"
+      val isInitialised = podStatus.conditions.exists { c =>
+        c._type == "Initialized" && c.status == "True"
       }
-      val isReady=podStatus.conditions.exists { c =>
-        c._type=="Ready" && c.status=="True"
+      val isReady = podStatus.conditions.exists { c =>
+        c._type == "Ready" && c.status == "True"
       }
       assert(isScheduled)
       assert(isInitialised)
@@ -62,23 +65,37 @@ class PodSpec extends K8SFixture with Eventually with Matchers {
     k8s.delete[Pod](nginxPodName).map { _ =>
       eventually(timeout(100 seconds), interval(3 seconds)) {
         val retrievePod = k8s.get[Pod](nginxPodName)
-        val podRetrieved=Await.ready(retrievePod, 2 seconds).value.get
+        val podRetrieved = Await.ready(retrievePod, 2 seconds).value.get
         podRetrieved match {
           case s: Success[_] => assert(false)
           case Failure(ex) => ex match {
-              case ex: K8SException if ex.status.code.contains(404) => assert(true)
-              case _ => assert(false)
-            }
+            case ex: K8SException if ex.status.code.contains(404) => assert(true)
+            case _ => assert(false)
+          }
         }
       }
     }
   }
 
-  def getNginxContainer(version: String): Container = Container(name = "nginx", image = "nginx:" + version).exposePort(80)
+  it should "delete selected pods" in { k8s =>
+    for {
+      _ <- k8s.create(getNginxPod(nginxPodName + "-foo", "1.7.9", labels = Map("foo" -> "1")))
+      _ <- k8s.create(getNginxPod(nginxPodName + "-bar", "1.7.9", labels = Map("bar" -> "2")))
+      _ <- k8s.deleteCollectionSelected[PodList](LabelSelector(LabelSelector.ExistsRequirement("foo")))
+    } yield eventually(timeout(100 seconds), interval(3 seconds)) {
+      val retrievePods = k8s.list[PodList]()
+      val podsRetrieved = Await.result(retrievePods, 2 seconds)
+      val podNamesRetrieved = podsRetrieved.items.map(_.name)
+      assert(!podNamesRetrieved.contains(nginxPodName + "-foo") && podNamesRetrieved.contains(nginxPodName + "-bar"))
+    }
+  }
 
-  def getNginxPod(name: String, version: String): Pod = {
-    val nginxContainer = getNginxContainer(version)
-    val nginxPodSpec = Pod.Spec(containers=List((nginxContainer)))
-    Pod.named(nginxPodName).copy(spec=Some(nginxPodSpec))
+  def getNginxContainer(name: String, version: String): Container = Container(name = name, image = "nginx:" + version).exposePort(80)
+
+  def getNginxPod(name: String, version: String, labels: Map[String, String] = Map()): Pod = {
+    val nginxContainer = getNginxContainer(name, version)
+    val nginxPodSpec = Pod.Spec(containers = List((nginxContainer)))
+    val podMeta=ObjectMeta(name = name, labels = labels ++ defaultLabels)
+    Pod(metadata = podMeta, spec = Some(nginxPodSpec))
   }
 }

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -556,6 +556,32 @@ package object client {
        } yield ()
      }
 
+     def deleteCollection[L <: ListResource[_]]()(
+       implicit fmt: Format[L], rd: ResourceDefinition[L], lc: LoggingContext=RequestLoggingContext()): Future[L] =
+     {
+       _deleteCollection[L](rd, None)
+     }
+
+     def deleteCollectionSelected[L <: ListResource[_]](labelSelector: LabelSelector)(
+       implicit fmt: Format[L], rd: ResourceDefinition[L], lc: LoggingContext=RequestLoggingContext()): Future[L] =
+     {
+       _deleteCollection[L](rd, Some(labelSelector))
+     }
+
+     private def _deleteCollection[L <: ListResource[_]](rd: ResourceDefinition[_], maybeLabelSelector: Option[LabelSelector])(
+       implicit fmt: Format[L], lc: LoggingContext=RequestLoggingContext()): Future[L] =
+     {
+       val queryOpt = maybeLabelSelector map { ls =>
+         Uri.Query("labelSelector" -> ls.toString)
+       }
+       if (log.isDebugEnabled) {
+         val lsInfo = maybeLabelSelector map { ls => s" with label selector '${ls.toString}'" } getOrElse ""
+         logDebug(s"[Delete request: resources of kind '${rd.spec.names.kind}'${lsInfo}")
+       }
+       val req = buildRequest(HttpMethods.DELETE, rd, None, query = queryOpt)
+       makeRequestReturningListResource[L](req)
+     }
+
      def getPodLogSource(name: String, queryParams: Pod.LogQueryParams, namespace: Option[String] = None)(
        implicit lc: LoggingContext=RequestLoggingContext()): Future[Source[ByteString, _]] =
      {

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -556,19 +556,19 @@ package object client {
        } yield ()
      }
 
-     def deleteCollection[L <: ListResource[_]]()(
+     def deleteAll[L <: ListResource[_]]()(
        implicit fmt: Format[L], rd: ResourceDefinition[L], lc: LoggingContext=RequestLoggingContext()): Future[L] =
      {
-       _deleteCollection[L](rd, None)
+       _deleteAll[L](rd, None)
      }
 
-     def deleteCollectionSelected[L <: ListResource[_]](labelSelector: LabelSelector)(
+     def deleteAllSelected[L <: ListResource[_]](labelSelector: LabelSelector)(
        implicit fmt: Format[L], rd: ResourceDefinition[L], lc: LoggingContext=RequestLoggingContext()): Future[L] =
      {
-       _deleteCollection[L](rd, Some(labelSelector))
+       _deleteAll[L](rd, Some(labelSelector))
      }
 
-     private def _deleteCollection[L <: ListResource[_]](rd: ResourceDefinition[_], maybeLabelSelector: Option[LabelSelector])(
+     private def _deleteAll[L <: ListResource[_]](rd: ResourceDefinition[_], maybeLabelSelector: Option[LabelSelector])(
        implicit fmt: Format[L], lc: LoggingContext=RequestLoggingContext()): Future[L] =
      {
        val queryOpt = maybeLabelSelector map { ls =>


### PR DESCRIPTION
I implemented delete collection methods so we don't have to call `delete()` one by one. Could you consider merging this change?

REF: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#delete-collection-pod-v1-core