### PR TITLE
Add support for PodDisruptionBudget

### DIFF
--- a/client/src/it/scala/skuber/PodDisruptionBudgetSpec.scala
+++ b/client/src/it/scala/skuber/PodDisruptionBudgetSpec.scala
@@ -53,8 +53,7 @@ class PodDisruptionBudgetSpec extends K8SFixture with Eventually with Matchers {
       ).flatMap { pdb =>
         k8s.delete[PodDisruptionBudget](pdb.name).flatMap { deleteResult =>
           k8s.get[PodDisruptionBudget](pdb.name).map { x =>
-            assert(x.spec.contains(PodDisruptionBudget.Spec(None, Some(1), Some("app" is "nginx"))))
-            assert(x.name == name)
+            assert(false)
           } recoverWith {
             case ex: K8SException if ex.status.code.contains(404) => assert(true)
             case _ => assert(false)

--- a/client/src/it/scala/skuber/PodDisruptionBudgetSpec.scala
+++ b/client/src/it/scala/skuber/PodDisruptionBudgetSpec.scala
@@ -1,0 +1,74 @@
+package skuber
+
+import org.scalatest.Matchers
+import org.scalatest.concurrent.Eventually
+import skuber.apps.v1.Deployment
+import skuber.policy.v1beta1.PodDisruptionBudget
+import skuber.policy.v1beta1.PodDisruptionBudget._
+
+class PodDisruptionBudgetSpec extends K8SFixture with Eventually with Matchers {
+  behavior of "PodDisruptionBudget"
+
+  it should "create a PodDisruptionBudget" in { k8s =>
+    val name: String = java.util.UUID.randomUUID().toString
+    k8s.create(getNginxDeployment(name, "1.7.9")) flatMap { d =>
+      import LabelSelector.dsl._
+      k8s.create(PodDisruptionBudget(name)
+        .withMinAvailable(Left(1))
+        .withLabelSelector("app" is "nginx")
+      ).map(result =>
+        assert(result.name == name)
+      )
+    }
+  }
+
+  it should "update a PodDisruptionBudget" in { k8s =>
+    val name: String = java.util.UUID.randomUUID().toString
+    k8s.create(getNginxDeployment(name, "1.7.9")) flatMap { d =>
+      import LabelSelector.dsl._
+      k8s.create(PodDisruptionBudget(name)
+        .withMinAvailable(Left(1))
+        .withLabelSelector("app" is "nginx")
+      ).flatMap(pdb =>
+        eventually(
+          k8s.get[PodDisruptionBudget](pdb.name).flatMap { updatedPdb =>
+            k8s.update(updatedPdb).map(result => //PodDisruptionBudget are immutable at the moment.
+              assert(result.name == name)
+            )
+          }
+        )
+      )
+    }
+  }
+
+  it should "delete a PodDisruptionBudget" in { k8s =>
+    val name: String = java.util.UUID.randomUUID().toString
+    k8s.create(getNginxDeployment(name, "1.7.9")) flatMap { d =>
+      import LabelSelector.dsl._
+      k8s.create(PodDisruptionBudget(name)
+        .withMinAvailable(Left(1))
+        .withLabelSelector("app" is "nginx")
+      ).flatMap { pdb =>
+        k8s.delete[PodDisruptionBudget](pdb.name).flatMap { deleteResult =>
+          k8s.get[PodDisruptionBudget](pdb.name).map(x =>
+            assert(false)
+          ) recoverWith {
+            case ex: K8SException if ex.status.code.contains(404) => assert(true)
+            case _ => assert(false)
+          }
+        }
+      }
+    }
+  }
+
+  def getNginxDeployment(name: String, version: String): Deployment = {
+    import LabelSelector.dsl._
+    val nginxContainer = getNginxContainer(version)
+    val nginxTemplate = Pod.Template.Spec.named("nginx").addContainer(nginxContainer).addLabel("app" -> "nginx")
+    Deployment(name).withTemplate(nginxTemplate).withLabelSelector("app" is "nginx")
+  }
+
+  def getNginxContainer(version: String): Container = {
+    Container(name = "nginx", image = "nginx:" + version).exposePort(80)
+  }
+}

--- a/client/src/main/scala/skuber/apps/v1/Deployment.scala
+++ b/client/src/main/scala/skuber/apps/v1/Deployment.scala
@@ -146,7 +146,7 @@ object Deployment {
   implicit val depStatusFmt: Format[Status] = (
     (JsPath \ "replicas").formatMaybeEmptyInt() and
     (JsPath \ "updatedReplicas").formatMaybeEmptyInt() and
-    (JsPath \ "readydReplicas").formatMaybeEmptyInt() and
+    (JsPath \ "readyReplicas").formatMaybeEmptyInt() and
     (JsPath \ "availableReplicas").formatMaybeEmptyInt() and
     (JsPath \ "unavailableReplicas").formatMaybeEmptyInt() and
     (JsPath \ "observedGeneration").formatMaybeEmptyInt() and

--- a/client/src/main/scala/skuber/policy/v1beta1/PodDisruptionBudget.scala
+++ b/client/src/main/scala/skuber/policy/v1beta1/PodDisruptionBudget.scala
@@ -1,7 +1,6 @@
 package skuber.policy.v1beta1
 
 import skuber.ResourceSpecification.{Names, Scope}
-import skuber.apps.v1.{StatefulSet, StatefulSetList}
 import skuber.{IntOrString, LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, ResourceDefinition, Scale, Timestamp}
 
 case class PodDisruptionBudget(override val kind: String = "PodDisruptionBudget",

--- a/client/src/main/scala/skuber/policy/v1beta1/PodDisruptionBudget.scala
+++ b/client/src/main/scala/skuber/policy/v1beta1/PodDisruptionBudget.scala
@@ -1,0 +1,90 @@
+package skuber.policy.v1beta1
+
+import skuber.ResourceSpecification.{Names, Scope}
+import skuber.apps.v1.{StatefulSet, StatefulSetList}
+import skuber.{IntOrString, LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectResource, ResourceDefinition, Scale, Timestamp}
+
+case class PodDisruptionBudget(override val kind: String = "PodDisruptionBudget",
+                               override val apiVersion: String = policyAPIVersion,
+                               metadata: ObjectMeta,
+                               spec: Option[PodDisruptionBudget.Spec] = None,
+                               status: Option[PodDisruptionBudget.Status] = None) extends ObjectResource {
+
+  private lazy val copySpec: PodDisruptionBudget.Spec = this.spec.getOrElse(PodDisruptionBudget.Spec(selector=Some(LabelSelector())))
+
+  def withLabelSelector(sel: LabelSelector): PodDisruptionBudget = {
+    this.copy(spec = Some(copySpec.copy(selector = Some(sel))))
+  }
+
+  def withMaxUnavailable(value: IntOrString): PodDisruptionBudget = {
+    this.copy(spec = Some(copySpec.copy(maxUnavailable = Some(value))))
+  }
+
+  def withMinAvailable(value: IntOrString): PodDisruptionBudget = {
+    this.copy(spec = Some(copySpec.copy(minAvailable = Some(value))))
+  }
+}
+
+object PodDisruptionBudget {
+
+  def apply(name: String): PodDisruptionBudget = {
+    PodDisruptionBudget(metadata = ObjectMeta(name = name))
+  }
+
+  val specification = NonCoreResourceSpecification(
+    apiGroup = "policy",
+    version = "v1beta1",
+    scope = Scope.Namespaced,
+    names = Names(
+      plural = "poddisruptionbudgets",
+      singular = "poddisruptionbudget",
+      kind = "PodDisruptionBudget",
+      shortNames = List("pdb")
+    )
+  )
+  implicit val stsDef: ResourceDefinition[PodDisruptionBudget] = new ResourceDefinition[PodDisruptionBudget] {
+    def spec: NonCoreResourceSpecification = specification
+  }
+  implicit val stsListDef: ResourceDefinition[PodDisruptionBudgetList] = new ResourceDefinition[PodDisruptionBudgetList] {
+    def spec: NonCoreResourceSpecification = specification
+  }
+  implicit val scDef: Scale.SubresourceSpec[PodDisruptionBudget] = new Scale.SubresourceSpec[PodDisruptionBudget] {
+    override def apiVersion: String = policyAPIVersion
+  }
+
+  case class Spec(maxUnavailable: Option[IntOrString] = None,
+                  minAvailable: Option[IntOrString] = None,
+                  selector: Option[LabelSelector] = None)
+
+  case class Status(currentHealthy: Int,
+                    desiredHealthy: Int,
+                    disruptedPods: Map[String, Timestamp],
+                    disruptionsAllowed: Int,
+                    expectedPods: Int,
+                    observedGeneration: Option[Int])
+
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json.{Format, JsPath}
+  import skuber.json.format._
+
+  implicit val depStatusFmt: Format[Status] = (
+    (JsPath \ "currentHealthy").formatMaybeEmptyInt() and
+      (JsPath \ "desiredHealthy").formatMaybeEmptyInt() and
+      (JsPath \ "disruptedPods").formatMaybeEmptyMap[Timestamp] and
+      (JsPath \ "disruptionsAllowed").formatMaybeEmptyInt() and
+      (JsPath \ "expectedPods").formatMaybeEmptyInt() and
+      (JsPath \ "observedGeneration").formatNullable[Int]
+    ) (Status.apply, unlift(Status.unapply))
+
+  implicit val depSpecFmt: Format[Spec] = (
+    (JsPath \ "maxUnavailable").formatNullable[IntOrString] and
+      (JsPath \ "minAvailable").formatNullable[IntOrString] and
+      (JsPath \ "selector").formatNullableLabelSelector
+    ) (Spec.apply, unlift(Spec.unapply))
+
+  implicit lazy val pdbFormat: Format[PodDisruptionBudget] = (
+    objFormat and
+      (JsPath \ "spec").formatNullable[Spec] and
+      (JsPath \ "status").formatNullable[Status]
+    )(PodDisruptionBudget.apply, unlift(PodDisruptionBudget.unapply))
+}

--- a/client/src/main/scala/skuber/policy/v1beta1/PodDisruptionBudget.scala
+++ b/client/src/main/scala/skuber/policy/v1beta1/PodDisruptionBudget.scala
@@ -47,9 +47,6 @@ object PodDisruptionBudget {
   implicit val stsListDef: ResourceDefinition[PodDisruptionBudgetList] = new ResourceDefinition[PodDisruptionBudgetList] {
     def spec: NonCoreResourceSpecification = specification
   }
-  implicit val scDef: Scale.SubresourceSpec[PodDisruptionBudget] = new Scale.SubresourceSpec[PodDisruptionBudget] {
-    override def apiVersion: String = policyAPIVersion
-  }
 
   case class Spec(maxUnavailable: Option[IntOrString] = None,
                   minAvailable: Option[IntOrString] = None,

--- a/client/src/main/scala/skuber/policy/v1beta1/package.scala
+++ b/client/src/main/scala/skuber/policy/v1beta1/package.scala
@@ -1,0 +1,8 @@
+package skuber.policy
+
+import skuber.ListResource
+
+package object v1beta1 {
+  val policyAPIVersion = "policy/v1beta1"
+  type PodDisruptionBudgetList = ListResource[skuber.policy.v1beta1.PodDisruptionBudget]
+}

--- a/client/src/test/resources/examplePodDisruptionBudget.json
+++ b/client/src/test/resources/examplePodDisruptionBudget.json
@@ -1,0 +1,1 @@
+{"kind":"PodDisruptionBudget","apiVersion":"policy/v1beta1","metadata":{"name":"someName"},"spec":{"maxUnavailable":2,"minAvailable":1,"selector":{"matchLabels":{"application":"someApplicationName"}}}}

--- a/client/src/test/scala/skuber/policy/v1beta1/PodDisruptionBudgetSpec.scala
+++ b/client/src/test/scala/skuber/policy/v1beta1/PodDisruptionBudgetSpec.scala
@@ -1,0 +1,34 @@
+package skuber.policy.v1beta1
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.{JsSuccess, Json}
+import skuber.LabelSelector.dsl._
+
+class PodDisruptionBudgetSpec extends Specification {
+  import PodDisruptionBudget._
+  "A PodDisruptionBudget can" >> {
+    "decoded from json" >> {
+      val pdb = PodDisruptionBudget("someName")
+        .withMaxUnavailable(Left(2))
+        .withMinAvailable(Left(1))
+        .withLabelSelector("application" is "someApplicationName")
+
+      Json.parse(createJson("/examplePodDisruptionBudget.json")).validate[PodDisruptionBudget] mustEqual JsSuccess(pdb)
+    }
+    "encode to json" >> {
+      Json.stringify(
+        Json.toJson(
+          PodDisruptionBudget("someName")
+            .withMaxUnavailable(Left(2))
+            .withMinAvailable(Left(1))
+            .withLabelSelector("application" is "someApplicationName")
+        )
+      ) mustEqual createJson("/examplePodDisruptionBudget.json")
+    }
+  }
+
+  private def createJson(file: String): String = {
+    val source = scala.io.Source.fromURL(getClass.getResource(file))
+    try source.mkString finally source.close()
+  }
+}


### PR DESCRIPTION
The PR adds support PodDisruptionBudget [1]. The resource entity is based on the spec defined here [2,3]. 

The PR also also contains units and IT tests for the new resource. 

Please let me know if there is anything you would like to be change. 

[1]https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
[2]https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#poddisruptionbudgetspec-v1beta1-policy
[3] https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/policy/types.go
