### PR TITLE
Handle Empty Values in Kube Config

### DIFF
--- a/client/src/main/scala/skuber/api/Configuration.scala
+++ b/client/src/main/scala/skuber/api/Configuration.scala
@@ -191,8 +191,12 @@ object Configuration {
         val k8sAuthInfoMap = topLevelYamlToK8SConfigMap("user", toK8SAuthInfo)
 
         def toK8SContext(contextConfig: YamlMap) = {
-          val cluster=contextConfig.asScala.get("cluster").flatMap(clusterName => k8sClusterMap.get(clusterName.asInstanceOf[String])).getOrElse(Cluster())
-          val authInfo =contextConfig.asScala.get("user").flatMap(userKey => k8sAuthInfoMap.get(userKey.asInstanceOf[String])).getOrElse(NoAuth)
+          val cluster=contextConfig.asScala.get("cluster").filterNot(_ == "").map { clusterName =>
+            k8sClusterMap.get(clusterName.asInstanceOf[String]).get
+          }.getOrElse(Cluster())
+          val authInfo =contextConfig.asScala.get("user").filterNot(_ == "").map { userKey =>
+            k8sAuthInfoMap.get(userKey.asInstanceOf[String]).get
+          }.getOrElse(NoAuth)
           val namespace=contextConfig.asScala.get("namespace").fold(Namespace.default) { name=>Namespace.forName(name.asInstanceOf[String]) }
           Context(cluster,authInfo,namespace)
         }

--- a/client/src/main/scala/skuber/api/Configuration.scala
+++ b/client/src/main/scala/skuber/api/Configuration.scala
@@ -191,8 +191,8 @@ object Configuration {
         val k8sAuthInfoMap = topLevelYamlToK8SConfigMap("user", toK8SAuthInfo)
 
         def toK8SContext(contextConfig: YamlMap) = {
-          val cluster=contextConfig.asScala.get("cluster").flatMap(clusterName => k8sClusterMap.get(clusterName.asInstanceOf[String])).get
-          val authInfo =contextConfig.asScala.get("user").flatMap(userKey => k8sAuthInfoMap.get(userKey.asInstanceOf[String])).get
+          val cluster=contextConfig.asScala.get("cluster").flatMap(clusterName => k8sClusterMap.get(clusterName.asInstanceOf[String])).getOrElse(Cluster())
+          val authInfo =contextConfig.asScala.get("user").flatMap(userKey => k8sAuthInfoMap.get(userKey.asInstanceOf[String])).getOrElse(NoAuth)
           val namespace=contextConfig.asScala.get("namespace").fold(Namespace.default) { name=>Namespace.forName(name.asInstanceOf[String]) }
           Context(cluster,authInfo,namespace)
         }


### PR DESCRIPTION
[Kubeadm](https://github.com/kubernetes/kubeadm) creates the following context in `$HOME/.kube/config` when it creates a cluster because it doesn't need authentication.

```
contexts:
- context:
    cluster: dind
    user: ""
  name: dind
```

However, skuber's `defaultK8sConfig` raises an error because it expects some authorization. Since `Context` has the default values for the constructor, I think we can rescue from this error with default values.