### PR TITLE
Define implicit configmap list format

### DIFF
--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -1049,6 +1049,7 @@ package object format {
 
   implicit val podListFmt: Format[PodList] = ListResourceFormat[Pod]
   implicit val nodeListFmt: Format[NodeList] = ListResourceFormat[Node]
+  implicit val configMapListFmt: Format[ConfigMapList] = ListResourceFormat[ConfigMap]
   implicit val serviceListFmt: Format[ServiceList] = ListResourceFormat[Service]
   implicit val endpointsListFmt: Format[EndpointsList] = ListResourceFormat[Endpoints]
   implicit val eventListFmt: Format[EventList] = ListResourceFormat[Event]


### PR DESCRIPTION
There's no implicit format conversion for configmap lists.