### PR TITLE
Implement the patch method

### DIFF
--- a/client/src/it/scala/skuber/PatchSpec.scala
+++ b/client/src/it/scala/skuber/PatchSpec.scala
@@ -53,7 +53,7 @@ class PatchSpec extends K8SFixture with Eventually with Matchers with BeforeAndA
 
   it should "patch a pod with strategic merge patch" in { k8s =>
     val randomString = java.util.UUID.randomUUID().toString
-    val patchData = new MetadataPatch(labels = Some(Map("foo" -> randomString)), annotations = None) with StrategicMergePatchStrategy
+    val patchData = new MetadataPatch(labels = Some(Map("foo" -> randomString)), annotations = None, strategy = StrategicMergePatchStrategy)
     k8s.patch[MetadataPatch, Pod](nginxPodName, patchData).map { _ =>
       eventually(timeout(10 seconds), interval(1 seconds)) {
         val retrievePod = k8s.get[Pod](nginxPodName)
@@ -70,7 +70,7 @@ class PatchSpec extends K8SFixture with Eventually with Matchers with BeforeAndA
 
   it should "patch a pod with json merge patch" in { k8s =>
     val randomString = java.util.UUID.randomUUID().toString
-    val patchData = new MetadataPatch(labels = Some(Map("foo" -> randomString)), annotations = None) with JsonMergePatchStrategy
+    val patchData = new MetadataPatch(labels = Some(Map("foo" -> randomString)), annotations = None, strategy = JsonMergePatchStrategy)
     k8s.patch[MetadataPatch, Pod](nginxPodName, patchData).map { _ =>
       eventually(timeout(10 seconds), interval(1 seconds)) {
         val retrievePod = k8s.get[Pod](nginxPodName)

--- a/client/src/it/scala/skuber/PatchSpec.scala
+++ b/client/src/it/scala/skuber/PatchSpec.scala
@@ -1,0 +1,117 @@
+package skuber
+
+import org.scalatest.{BeforeAndAfterAll, Matchers}
+import org.scalatest.concurrent.Eventually
+import skuber.json.format._
+
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.util.Success
+
+
+class PatchSpec extends K8SFixture with Eventually with Matchers with BeforeAndAfterAll {
+  val nginxPodName: String = java.util.UUID.randomUUID().toString
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val k8s = k8sInit
+    Await.result(k8s.create(getNginxPod(nginxPodName, "1.7.9")), 3 second)
+    // Let the pod running
+    Thread.sleep(3000)
+    k8s.close
+  }
+
+  override def afterAll(): Unit = {
+    val k8s = k8sInit
+    Await.result(k8s.delete[Pod](nginxPodName), 3 second)
+    Thread.sleep(3000)
+    k8s.close
+
+    super.afterAll()
+  }
+
+  behavior of "Patch"
+
+  it should "patch a pod with strategic merge patch by default" in { k8s =>
+    val randomString = java.util.UUID.randomUUID().toString
+    val patchData = MetadataPatch(labels = Some(Map("foo" -> randomString)), annotations = None)
+    k8s.patch[MetadataPatch, Pod](nginxPodName, patchData).map { _ =>
+      eventually(timeout(10 seconds), interval(1 seconds)) {
+        val retrievePod = k8s.get[Pod](nginxPodName)
+        val podRetrieved = Await.ready(retrievePod, 2 seconds).value.get
+        podRetrieved match {
+          case Success(pod: Pod) =>
+            assert(pod.metadata.labels == Map("label" -> "1", "foo" -> randomString))
+            assert(pod.metadata.annotations == Map())
+          case _ => assert(false)
+        }
+      }
+    }
+  }
+
+  it should "patch a pod with strategic merge patch" in { k8s =>
+    val randomString = java.util.UUID.randomUUID().toString
+    val patchData = new MetadataPatch(labels = Some(Map("foo" -> randomString)), annotations = None) with StrategicMergePatchStrategy
+    k8s.patch[MetadataPatch, Pod](nginxPodName, patchData).map { _ =>
+      eventually(timeout(10 seconds), interval(1 seconds)) {
+        val retrievePod = k8s.get[Pod](nginxPodName)
+        val podRetrieved = Await.ready(retrievePod, 2 seconds).value.get
+        podRetrieved match {
+          case Success(pod: Pod) =>
+            assert(pod.metadata.labels == Map("label" -> "1", "foo" -> randomString))
+            assert(pod.metadata.annotations == Map())
+          case _ => assert(false)
+        }
+      }
+    }
+  }
+
+  it should "patch a pod with json merge patch" in { k8s =>
+    val randomString = java.util.UUID.randomUUID().toString
+    val patchData = new MetadataPatch(labels = Some(Map("foo" -> randomString)), annotations = None) with JsonMergePatchStrategy
+    k8s.patch[MetadataPatch, Pod](nginxPodName, patchData).map { _ =>
+      eventually(timeout(10 seconds), interval(1 seconds)) {
+        val retrievePod = k8s.get[Pod](nginxPodName)
+        val podRetrieved = Await.ready(retrievePod, 2 seconds).value.get
+        podRetrieved match {
+          case Success(pod: Pod) =>
+            assert(pod.metadata.labels == Map("label" -> "1", "foo" -> randomString))
+            assert(pod.metadata.annotations == Map())
+          case _ => assert(false)
+        }
+      }
+    }
+  }
+
+  it should "patch a pod with json patch" in { k8s =>
+    val randomString = java.util.UUID.randomUUID().toString
+    val annotations = Map("skuber" -> "wow")
+    val patchData = JsonPatchOperationList(List(
+      JsonPatchOperation.Add("/metadata/labels/foo", randomString),
+      JsonPatchOperation.Add("/metadata/annotations", randomString),
+      JsonPatchOperation.Remove("/metadata/annotations"),
+    ))
+    k8s.patch[JsonPatchOperationList, Pod](nginxPodName, patchData).map { _ =>
+      eventually(timeout(10 seconds), interval(1 seconds)) {
+        val retrievePod = k8s.get[Pod](nginxPodName)
+        val podRetrieved = Await.ready(retrievePod, 2 seconds).value.get
+        podRetrieved match {
+          case Success(pod: Pod) =>
+            assert(pod.metadata.labels == Map("label" -> "1", "foo" -> randomString))
+            assert(pod.metadata.annotations == Map())
+          case _ => assert(false)
+        }
+      }
+    }
+  }
+
+  def getNginxContainer(version: String): Container = Container(name = "nginx", image = "nginx:" + version).exposePort(80)
+
+  def getNginxPod(name: String, version: String): Pod = {
+    val nginxContainer = getNginxContainer(version)
+    val nginxPodSpec = Pod.Spec(containers = List((nginxContainer)))
+    Pod(metadata = ObjectMeta(nginxPodName, labels = Map("label" -> "1"), annotations = Map("annotation" -> "1"))
+      , spec = Some(nginxPodSpec))
+  }
+}

--- a/client/src/it/scala/skuber/PatchSpec.scala
+++ b/client/src/it/scala/skuber/PatchSpec.scala
@@ -2,6 +2,7 @@ package skuber
 
 import org.scalatest.{BeforeAndAfterAll, Matchers}
 import org.scalatest.concurrent.Eventually
+import skuber.api.patch._
 import skuber.json.format._
 
 import scala.concurrent.duration._

--- a/client/src/main/scala/skuber/api/package.scala
+++ b/client/src/main/scala/skuber/api/package.scala
@@ -30,6 +30,7 @@ import skuber.json.format._
 import skuber.json.format.apiobj._
 import skuber._
 import skuber.api.WatchSource.Start
+import skuber.api.patch.{CustomMediaTypes, JsonMergePatchStrategy, JsonPatchStrategy, StrategicMergePatchStrategy}
 
 import scala.concurrent.duration._
 

--- a/client/src/main/scala/skuber/api/patch.scala
+++ b/client/src/main/scala/skuber/api/patch.scala
@@ -1,0 +1,67 @@
+package skuber.api
+
+import akka.http.scaladsl.model.{HttpCharsets, MediaType}
+import play.api.libs.json.Writes
+
+package object patch {
+
+  object CustomMediaTypes {
+    val `application/merge-patch+json` = MediaType.applicationWithFixedCharset("merge-patch+json", HttpCharsets.`UTF-8`)
+    val `application/strategic-merge-patch+json` = MediaType.applicationWithFixedCharset("strategic-merge-patch+json", HttpCharsets.`UTF-8`)
+  }
+
+  object JsonPatchOperation {
+    sealed trait Operation {
+      def op: String
+    }
+
+    trait ValueOperation[T] extends Operation {
+      type ValueType = T
+      def path: String
+      def value: ValueType
+      def fmt: Writes[T]
+    }
+
+    trait UnaryOperation extends Operation {
+      def path: String
+    }
+
+    trait DirectionalOperation extends Operation {
+      def from: String
+      def path: String
+    }
+
+    case class Add[T](path: String, value: T)(implicit val fmt: Writes[T]) extends ValueOperation[T] {
+      val op = "add"
+    }
+
+    case class Remove(path: String) extends UnaryOperation {
+      val op = "remove"
+    }
+
+    case class Replace[T](path: String, value: T)(implicit val fmt: Writes[T]) extends ValueOperation[T] {
+      val op = "replace"
+    }
+
+    case class Move(from: String, path: String) extends DirectionalOperation {
+      val op = "move"
+    }
+
+    case class Copy(from: String, path: String) extends DirectionalOperation {
+      val op = "copy"
+    }
+  }
+
+  sealed trait PatchStrategy
+
+  trait StrategicMergePatchStrategy extends PatchStrategy
+
+  trait JsonMergePatchStrategy extends PatchStrategy
+
+  trait JsonPatchStrategy extends PatchStrategy
+
+  case class JsonPatchOperationList(operations: List[JsonPatchOperation.Operation]) extends JsonPatchStrategy
+
+  case class MetadataPatch(labels: Option[Map[String, String]] = Some(Map()), annotations: Option[Map[String, String]] = Some(Map()))
+
+}

--- a/client/src/main/scala/skuber/api/patch.scala
+++ b/client/src/main/scala/skuber/api/patch.scala
@@ -52,16 +52,26 @@ package object patch {
     }
   }
 
+  sealed trait Patch {
+    val strategy: PatchStrategy
+  }
+
   sealed trait PatchStrategy
 
-  trait StrategicMergePatchStrategy extends PatchStrategy
+  sealed trait MergePatchStrategy extends PatchStrategy
 
-  trait JsonMergePatchStrategy extends PatchStrategy
+  case object StrategicMergePatchStrategy extends MergePatchStrategy
 
-  trait JsonPatchStrategy extends PatchStrategy
+  case object JsonMergePatchStrategy extends MergePatchStrategy
 
-  case class JsonPatchOperationList(operations: List[JsonPatchOperation.Operation]) extends JsonPatchStrategy
+  case object JsonPatchStrategy extends PatchStrategy
 
-  case class MetadataPatch(labels: Option[Map[String, String]] = Some(Map()), annotations: Option[Map[String, String]] = Some(Map()))
+  case class JsonPatchOperationList(operations: List[JsonPatchOperation.Operation]) extends Patch {
+    override val strategy = JsonPatchStrategy
+  }
+
+  case class MetadataPatch(labels: Option[Map[String, String]] = Some(Map()),
+                           annotations: Option[Map[String, String]] = Some(Map()),
+                           override val strategy: MergePatchStrategy = StrategicMergePatchStrategy) extends Patch
 
 }

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -1096,6 +1096,39 @@ package object format {
       (JsPath \ "object").format[T]
     )(WatchEvent.apply[T] _, unlift(WatchEvent.unapply[T]))
     
-  }  
+  }
+
+  implicit def jsonPatchOperationWrite = Writes[JsonPatchOperation.Operation] { value =>
+    JsObject(Map("op" -> JsString(value.op)) ++ (value match {
+      case v: JsonPatchOperation.ValueOperation[_] =>
+        Map(
+          "path" -> JsString(v.path),
+          "value" -> v.fmt.writes(v.value)
+        )
+      case v: JsonPatchOperation.UnaryOperation =>
+        Map(
+          "path" -> JsString(v.path)
+        )
+      case v: JsonPatchOperation.DirectionalOperation =>
+        Map(
+          "from" -> JsString(v.from),
+          "path" -> JsString(v.path)
+        )
+    }))
+  }
+
+  implicit def jsonPatchOperationListWrite = Writes[JsonPatchOperationList] { value =>
+    JsArray(value.operations.map(jsonPatchOperationWrite.writes)) }
+
+  implicit val metadataPatchWrite = Writes[MetadataPatch] { value =>
+    val labels = value.labels.map {
+      m => JsObject(m.mapValues(JsString))
+    }.getOrElse(JsNull)
+    val annotations = value.annotations.map {
+      m => JsObject(m.mapValues(JsString))
+    }.getOrElse(JsNull)
+    val metadata = JsObject(Map("labels" -> labels, "annotations" -> annotations))
+    JsObject(Map("metadata" -> metadata))
+  }
 }
 

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -8,6 +8,7 @@ import org.apache.commons.codec.binary.Base64
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import skuber._
+import skuber.api.patch.{JsonPatchOperation, JsonPatchOperationList, MetadataPatch}
 
 /**
  * @author David O'Riordan

--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -224,65 +224,6 @@ package object skuber {
     val TCP, UDP = Value
   }
 
-  object CustomMediaTypes {
-    val `application/merge-patch+json` = MediaType.applicationWithFixedCharset("merge-patch+json", HttpCharsets.`UTF-8`)
-    val `application/strategic-merge-patch+json` = MediaType.applicationWithFixedCharset("strategic-merge-patch+json", HttpCharsets.`UTF-8`)
-  }
-
-  object JsonPatchOperation {
-    sealed trait Operation {
-      def op: String
-    }
-
-    trait ValueOperation[T] extends Operation {
-      type ValueType = T
-      def path: String
-      def value: ValueType
-      def fmt: Writes[T]
-    }
-
-    trait UnaryOperation extends Operation {
-      def path: String
-    }
-
-    trait DirectionalOperation extends Operation {
-      def from: String
-      def path: String
-    }
-
-    case class Add[T](path: String, value: T)(implicit val fmt: Writes[T]) extends ValueOperation[T] {
-      val op = "add"
-    }
-
-    case class Remove(path: String) extends UnaryOperation {
-      val op = "remove"
-    }
-
-    case class Replace[T](path: String, value: T)(implicit val fmt: Writes[T]) extends ValueOperation[T] {
-      val op = "replace"
-    }
-
-    case class Move(from: String, path: String) extends DirectionalOperation {
-      val op = "move"
-    }
-
-    case class Copy(from: String, path: String) extends DirectionalOperation {
-      val op = "copy"
-    }
-  }
-
-  sealed trait PatchStrategy
-
-  trait StrategicMergePatchStrategy extends PatchStrategy
-
-  trait JsonMergePatchStrategy extends PatchStrategy
-
-  trait JsonPatchStrategy extends PatchStrategy
-
-  case class JsonPatchOperationList(operations: List[JsonPatchOperation.Operation]) extends JsonPatchStrategy
-
-  case class MetadataPatch(labels: Option[Map[String, String]] = Some(Map()), annotations: Option[Map[String, String]] = Some(Map()))
-
   // Delete options are (optionally) passed with a Delete request
   object DeletePropagation extends Enumeration {
     type DeletePropagation = Value

--- a/client/src/main/scala/skuber/package.scala
+++ b/client/src/main/scala/skuber/package.scala
@@ -2,9 +2,10 @@
 import scala.language.implicitConversions
 import java.net.URL
 
+import akka.http.scaladsl.model.{HttpCharsets, MediaType}
 import akka.stream.Materializer
 import com.typesafe.config.Config
-import play.api.libs.json.Format
+import play.api.libs.json._
 import skuber.api.client.{RequestContext, Status}
 
 /*
@@ -222,6 +223,65 @@ package object skuber {
     type Protocol = Value
     val TCP, UDP = Value
   }
+
+  object CustomMediaTypes {
+    val `application/merge-patch+json` = MediaType.applicationWithFixedCharset("merge-patch+json", HttpCharsets.`UTF-8`)
+    val `application/strategic-merge-patch+json` = MediaType.applicationWithFixedCharset("strategic-merge-patch+json", HttpCharsets.`UTF-8`)
+  }
+
+  object JsonPatchOperation {
+    sealed trait Operation {
+      def op: String
+    }
+
+    trait ValueOperation[T] extends Operation {
+      type ValueType = T
+      def path: String
+      def value: ValueType
+      def fmt: Writes[T]
+    }
+
+    trait UnaryOperation extends Operation {
+      def path: String
+    }
+
+    trait DirectionalOperation extends Operation {
+      def from: String
+      def path: String
+    }
+
+    case class Add[T](path: String, value: T)(implicit val fmt: Writes[T]) extends ValueOperation[T] {
+      val op = "add"
+    }
+
+    case class Remove(path: String) extends UnaryOperation {
+      val op = "remove"
+    }
+
+    case class Replace[T](path: String, value: T)(implicit val fmt: Writes[T]) extends ValueOperation[T] {
+      val op = "replace"
+    }
+
+    case class Move(from: String, path: String) extends DirectionalOperation {
+      val op = "move"
+    }
+
+    case class Copy(from: String, path: String) extends DirectionalOperation {
+      val op = "copy"
+    }
+  }
+
+  sealed trait PatchStrategy
+
+  trait StrategicMergePatchStrategy extends PatchStrategy
+
+  trait JsonMergePatchStrategy extends PatchStrategy
+
+  trait JsonPatchStrategy extends PatchStrategy
+
+  case class JsonPatchOperationList(operations: List[JsonPatchOperation.Operation]) extends JsonPatchStrategy
+
+  case class MetadataPatch(labels: Option[Map[String, String]] = Some(Map()), annotations: Option[Map[String, String]] = Some(Map()))
 
   // Delete options are (optionally) passed with a Delete request
   object DeletePropagation extends Enumeration {


### PR DESCRIPTION
I made `patch` method which is easier to use than `jsonMergePatch`. It also supports different merge strategies supported by Kubernetes. Could you review and consider merging it?