### PR TITLE
Format size limit of EmptyDir

### DIFF
--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -484,7 +484,7 @@ package object format {
   })
 
   implicit val emptyDirFormat: Format[EmptyDir] = (
-    (JsPath \ "medium").format[StorageMedium] and
+    (JsPath \ "medium").formatWithDefault[StorageMedium](DefaultStorageMedium) and
     (JsPath \ "sizeLimit").formatNullable[Resource.Quantity]
   )(EmptyDir.apply _, unlift(EmptyDir.unapply))
 

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -472,23 +472,22 @@ package object format {
   implicit val lifecycleFormat: Format[Lifecycle] = Json.format[Lifecycle]
   
   import Volume._
-  
-  implicit val emptyDirReads: Reads[EmptyDir] = {
-      (JsPath \ "medium").readNullable[String].map {
-        case Some(med) if med == "Memory" => EmptyDir(MemoryStorageMedium)
-        case Some(med) if med == "HugePages" => EmptyDir(HugePagesStorageMedium)
-        case _ => EmptyDir(DefaultStorageMedium)
-      }
-  }  
-  implicit val emptyDirWrites: Writes[EmptyDir] = Writes[EmptyDir] {
-    ed => ed.medium match {
-      case DefaultStorageMedium => (JsPath \ "medium").write[String].writes("")
-      case MemoryStorageMedium => (JsPath \ "medium").write[String].writes("Memory")
-      case HugePagesStorageMedium => (JsPath \ "medium").write[String].writes("HugePages")
-    }
-  }  
-  implicit val emptyDirFormat: Format[EmptyDir] = Format(emptyDirReads, emptyDirWrites)
-  
+
+  implicit val storageMediumFormat: Format[StorageMedium] = Format[StorageMedium](Reads[StorageMedium] {
+    case JsString(med) if med == "Memory" => JsSuccess(MemoryStorageMedium)
+    case JsString(med) if med == "HugePages" => JsSuccess(HugePagesStorageMedium)
+    case _ => JsSuccess(DefaultStorageMedium)
+  }, Writes[StorageMedium] {
+    case DefaultStorageMedium => JsString("")
+    case MemoryStorageMedium => JsString("Memory")
+    case HugePagesStorageMedium => JsString("HugePages")
+  })
+
+  implicit val emptyDirFormat: Format[EmptyDir] = (
+    (JsPath \ "medium").format[StorageMedium] and
+    (JsPath \ "sizeLimit").formatNullable[Resource.Quantity]
+  )(EmptyDir.apply _, unlift(EmptyDir.unapply))
+
   implicit val hostPathFormat: Format[HostPath] = Json.format[HostPath]
   implicit val keyToPathFormat: Format[KeyToPath] = Json.format[KeyToPath]
   implicit val volumeSecretFormat: Format[skuber.Volume.Secret] = Json.format[skuber.Volume.Secret]

--- a/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
@@ -55,15 +55,13 @@ class VolumeReadWriteSpec extends Specification {
   // Volume reader and writer
   "A Volume spec can be symmetrically written to json and the same value read back in\n" >> {
     "this can be done for the emptydir type source spec" >> {
-      val edVol = Volume("myVol", Volume.EmptyDir())
+      val edVol = Volume("myVol", Volume.EmptyDir(
+        Volume.HugePagesStorageMedium,
+        sizeLimit = Some(Resource.Quantity("100M"))))
       val myVolJson = Json.toJson(edVol)
       val readVol = Json.fromJson[Volume](myVolJson).get
       readVol.name mustEqual "myVol"
-      readVol.source match { 
-        case Volume.EmptyDir(medium,_) => medium mustEqual Volume.DefaultStorageMedium
-        case _ => Failure("not an emptyDir!")
-      }
-      readVol.source mustEqual Volume.EmptyDir()
+      readVol.source mustEqual Volume.EmptyDir(Volume.HugePagesStorageMedium, Some(Resource.Quantity("100M")))
     }
 
     "this can be done for the a hostpath type source" >> {

--- a/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
@@ -62,6 +62,12 @@ class VolumeReadWriteSpec extends Specification {
       val readVol = Json.fromJson[Volume](myVolJson).get
       readVol.name mustEqual "myVol"
       readVol.source mustEqual Volume.EmptyDir(Volume.HugePagesStorageMedium, Some(Resource.Quantity("100M")))
+
+      // Ensure empty EmptyDir is still deserizeable
+      val emptyEmptyDirJson = JsObject.empty
+      val readEmptyDir = Json.fromJson[Volume.EmptyDir](emptyEmptyDirJson).get
+      readEmptyDir.medium mustEqual Volume.DefaultStorageMedium
+      readEmptyDir.sizeLimit mustEqual None
     }
 
     "this can be done for the a hostpath type source" >> {


### PR DESCRIPTION
It seems `sizeLimit` of `EmptyDir` is not set correctly. I need it in my project. Would you consider merging the fix?