### PR TITLE
Improve pod log

### DIFF
--- a/client/src/it/scala/skuber/K8SFixture.scala
+++ b/client/src/it/scala/skuber/K8SFixture.scala
@@ -14,8 +14,10 @@ trait K8SFixture extends fixture.AsyncFlatSpec {
   implicit val materializer = ActorMaterializer()
   implicit val dispatcher = system.dispatcher
 
+  val config = ConfigFactory.load()
+
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val k8s = k8sInit
+    val k8s = k8sInit(config)
     complete {
       withFixture(test.toNoArgAsyncTest(k8s))
     } lastly {

--- a/client/src/it/scala/skuber/PodLogSpec.scala
+++ b/client/src/it/scala/skuber/PodLogSpec.scala
@@ -53,7 +53,8 @@ class PodLogSpec extends K8SFixture with Eventually with Matchers with BeforeAnd
     k8s.getPodLogSource(podName, LogQueryParams(follow = Some(true))).flatMap { source =>
       source.map(_.utf8String).runForeach(log += _)
     }.failed.map { case e: TcpIdleTimeoutException =>
-      assert(e.getMessage.matches(s"TCP idle-timeout encountered on connection to [^,]+, no bytes passed in the last ${idleTimeout}"))
+      val msgPattern = s"TCP idle-timeout encountered on connection to [^,]+, no bytes passed in the last ${idleTimeout}"
+      assert(e.getMessage.matches(msgPattern), s"""["${e.getMessage}"] does not match ["${msgPattern}"]""")
       assert(log == "foo\n")
       assert(ZonedDateTime.now().isAfter(start.withSecond(idleTimeout.toSeconds.toInt)))
     }

--- a/client/src/it/scala/skuber/PodLogSpec.scala
+++ b/client/src/it/scala/skuber/PodLogSpec.scala
@@ -1,0 +1,73 @@
+package skuber
+
+import java.time.ZonedDateTime
+
+import akka.stream.scaladsl.TcpIdleTimeoutException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{BeforeAndAfterAll, Matchers}
+import org.scalatest.concurrent.Eventually
+import skuber.Pod.LogQueryParams
+import skuber.json.format._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class PodLogSpec extends K8SFixture with Eventually with Matchers with BeforeAndAfterAll {
+  val podName: String = java.util.UUID.randomUUID().toString
+
+  behavior of "PodLog"
+
+  val idleTimeout = 3 seconds
+  override val config = ConfigFactory.parseString(s"skuber.pod-log.idle-timeout=${idleTimeout.toSeconds}s").withFallback(ConfigFactory.load())
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val k8s = k8sInit(config)
+    Await.result(k8s.create(getNginxPod(podName, "1.7.9")), 3 second)
+    // Let the pod running
+    Thread.sleep(3000)
+    k8s.close
+  }
+
+  override def afterAll(): Unit = {
+    val k8s = k8sInit(config)
+    Await.result(k8s.delete[Pod](podName), 3 second)
+    Thread.sleep(3000)
+    k8s.close
+
+    super.afterAll()
+  }
+
+  it should "get log of a pod" in { k8s =>
+    k8s.getPodLogSource(podName, LogQueryParams(follow = Some(false))).flatMap { source =>
+      source.map(_.utf8String).runReduce(_ + _).map { s =>
+        assert(s == "foo\n")
+      }
+    }
+  }
+
+  it should "tail log of a pod and timeout after a while" in { k8s =>
+    var log = ""
+    var start = ZonedDateTime.now()
+    k8s.getPodLogSource(podName, LogQueryParams(follow = Some(true))).flatMap { source =>
+      source.map(_.utf8String).runForeach(log += _)
+    }.failed.map { case e: TcpIdleTimeoutException =>
+      assert(e.getMessage.matches(s"TCP idle-timeout encountered on connection to [^,]+, no bytes passed in the last ${idleTimeout}"))
+      assert(log == "foo\n")
+      assert(ZonedDateTime.now().isAfter(start.withSecond(idleTimeout.toSeconds.toInt)))
+    }
+  }
+
+  def getNginxContainer(version: String): Container = Container(
+    name = "ubuntu", image = "nginx:" + version,
+    command = List("sh"),
+    args = List("-c", s"""echo "foo"; trap exit TERM; sleep infinity & wait""")
+  )
+
+  def getNginxPod(name: String, version: String): Pod = {
+    val container = getNginxContainer(version)
+    val podSpec = Pod.Spec(containers = List((container)))
+    Pod.named(podName).copy(spec = Some(podSpec))
+  }
+}

--- a/client/src/main/resources/reference.conf
+++ b/client/src/main/resources/reference.conf
@@ -10,6 +10,11 @@ skuber {
     idle-timeout = null
   }
 
+  pod-log {
+    # The idle timeout duration for any connections used by skuber `pod log` requests - if null the timeout is infinite.
+    idle-timeout = null
+  }
+
   watch-continuously {
     # Timeout that is passed to the kubernetes cluster for all list/watch calls. This limits the duration of the call,
     # regardless of any activity or inactivity.

--- a/client/src/main/scala/skuber/api/Watch.scala
+++ b/client/src/main/scala/skuber/api/Watch.scala
@@ -33,7 +33,7 @@ object Watch {
 
     val maybeResourceVersionQuery = sinceResourceVersion map { version => Uri.Query("resourceVersion" -> version) }
     val request = context.buildRequest(HttpMethods.GET, rd, Some(name), query = maybeResourceVersionQuery, watch = true)
-    val responseFut = context.invoke(request, watch = true)
+    val responseFut = context.invokeWatch(request)
     toFutureWatchEventSource(context, responseFut, bufSize)
   }
 
@@ -54,7 +54,7 @@ object Watch {
 
     val maybeResourceVersionQuery = sinceResourceVersion map { v => Uri.Query("resourceVersion" -> v) }
     val request = context.buildRequest(HttpMethods.GET, rd, None, query = maybeResourceVersionQuery, watch = true)
-    val responseFut = context.invoke(request, watch = true)
+    val responseFut = context.invokeWatch(request)
     toFutureWatchEventSource(context, responseFut, bufSize)
   }
 


### PR DESCRIPTION
I made `idleTimeout` configurable for the `getPodLogSource` method because pod logs sometimes become idle of longer than 60 seconds which is [the default of `akka-http`](https://doc.akka.io/docs/akka-http/current/common/timeouts.html#common-timeouts).