### PR TITLE
Implement field selector in the listSelected method

### DIFF
--- a/client/src/main/scala/skuber/FieldSelector.scala
+++ b/client/src/main/scala/skuber/FieldSelector.scala
@@ -1,0 +1,44 @@
+package skuber
+
+
+case class FieldSelector(val requirements: FieldSelector.Requirement*) {
+  override def toString = requirements.mkString(",")
+
+  override def equals(o: Any) = o match {
+    case that: FieldSelector => that.requirements.sortBy(r => r.key).equals(requirements.sortBy(r => r.key))
+    case _ => false
+  }
+}
+
+
+object FieldSelector {
+
+  sealed trait Requirement {
+    val key: String
+  }
+
+  case class IsEqualRequirement(key: String, value: String) extends Requirement {
+    override def toString = key + "=" + value
+  }
+
+  case class IsNotEqualRequirement(key: String, value: String) extends Requirement {
+    override def toString = key + "!=" + value
+  }
+
+  object dsl {
+
+    // this little DSL enables equality selector requirements to be specified using a simple syntax
+    // analogous to the native k8s one, with renamed operators to avoid confusion with standard/common Scala ops.
+    // The following illustrates mappings from this DSL to k8s selector requirements syntax:
+    // "tier" is "frontend" -> "tier=frontend"
+    // "status" isNot "release" -> "status!=release"
+    implicit class strToReq(key: String) {
+      def is(value: String) = IsEqualRequirement(key, value)
+
+      def isNot(value: String) = IsNotEqualRequirement(key, value)
+    }
+
+    implicit def reqToSel(req: FieldSelector.Requirement) = FieldSelector(req)
+  }
+
+}

--- a/client/src/test/scala/skuber/model/FieldSelectorSpec.scala
+++ b/client/src/test/scala/skuber/model/FieldSelectorSpec.scala
@@ -1,0 +1,35 @@
+package skuber
+
+import org.specs2.mutable.Specification
+
+import FieldSelector.dsl._
+
+
+class FieldSelectorSpec extends Specification {
+  "A field selector can be constructed" >> {
+    "from a field equality requirement" >> {
+      val sel = FieldSelector("env" is "production")
+      sel.requirements.size mustEqual 1
+      sel.requirements(0) mustEqual FieldSelector.IsEqualRequirement("env", "production")
+    }
+  }
+
+  "A field selector can be constructed" >> {
+    "from a field inequality requirement" >> {
+      val sel = FieldSelector("env" isNot "production")
+      sel.requirements.size mustEqual 1
+      sel.requirements(0) mustEqual FieldSelector.IsNotEqualRequirement("env", "production")
+    }
+  }
+
+  "A field selector can be constructed" >> {
+    "from multiple requirements" >> {
+      val sel = FieldSelector(
+        "tier" is "frontend",
+        "env" isNot "production")
+      sel.requirements.size mustEqual 2
+      sel.requirements(0) mustEqual FieldSelector.IsEqualRequirement("tier", "frontend")
+      sel.requirements(1) mustEqual FieldSelector.IsNotEqualRequirement("env", "production")
+    }
+  }
+}


### PR DESCRIPTION
I have implemented `fieldSelector` in the `listSelected` method as I need it to list pods efficiently in my project.

Unlike `labelSelector`, `fieldSelector` only supports `==` and `!=` according to [the document](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/).

I hope this can be included into version `2.0.12` but if it's not possible, please consider adding this feature in `2.1`.