### PR TITLE
Make Patch trait not sealed

### DIFF
--- a/client/src/main/scala/skuber/api/patch.scala
+++ b/client/src/main/scala/skuber/api/patch.scala
@@ -52,7 +52,7 @@ package object patch {
     }
   }
 
-  sealed trait Patch {
+  trait Patch {
     val strategy: PatchStrategy
   }
 


### PR DESCRIPTION
If the trait is sealed, we can not define classes with it outside of this package.