### PR TITLE
Update security context

### DIFF
--- a/client/src/main/scala/skuber/Container.scala
+++ b/client/src/main/scala/skuber/Container.scala
@@ -23,7 +23,7 @@ case class Container(
     terminationMessagePath: Option[String] = None,
     terminationMessagePolicy: Option[Container.TerminationMessagePolicy.Value] = None,
     imagePullPolicy: Container.PullPolicy.Value = Container.PullPolicy.IfNotPresent,
-    securityContext: Option[Security.Context] = None,
+    securityContext: Option[SecurityContext] = None,
     envFrom: List[EnvFromSource] = Nil,
     stdin: Option[Boolean] = None,
     stdinOnce: Option[Boolean] = None,

--- a/client/src/main/scala/skuber/Pod.scala
+++ b/client/src/main/scala/skuber/Pod.scala
@@ -40,7 +40,7 @@ object Pod {
     imagePullSecrets: List[LocalObjectReference] = List(),
     affinity: Option[Affinity] = None,
     tolerations: List[Toleration] = List(),
-    securityContext: Option[Security.Context] = None,
+    securityContext: Option[PodSecurityContext] = None,
     hostname: Option[String] = None,
     hostAliases: List[HostAlias] = Nil,
     hostPID: Option[Boolean] = None,

--- a/client/src/main/scala/skuber/Security.scala
+++ b/client/src/main/scala/skuber/Security.scala
@@ -1,32 +1,48 @@
 package skuber
 
 /**
- * @author David O'Riordan
- */
+  * @author David O'Riordan
+  */
+
+import Security._
+
+case class SecurityContext(
+                            allowPrivilegeEscalation: Option[Boolean] = None,
+                            capabilities: Option[Capabilities] = None,
+                            privileged: Option[Boolean] = None,
+                            readOnlyRootFilesystem: Option[Boolean] = None,
+                            runAsGroup: Option[Int] = None,
+                            runAsNonRoot: Option[Boolean] = None,
+                            runAsUser: Option[Int] = None,
+                            seLinuxOptions: Option[SELinuxOptions] = None
+                          )
+
+case class PodSecurityContext(
+                               fsGroup: Option[Int] = None,
+                               runAsGroup: Option[Int] = None,
+                               runAsNonRoot: Option[Boolean] = None,
+                               runAsUser: Option[Int] = None,
+                               seLinuxOptions: Option[SELinuxOptions] = None,
+                               supplementalGroups: List[Int] = Nil,
+                               sysctls: List[Sysctl] = Nil
+                             )
 
 object Security {
-  // Note: Context can be set at pod and/or container level but certain attributes are level-specific
-  case class Context(
-      capabilities: Option[Capabilities] = None, 
-      privileged: Option[Boolean] = None,
-      seLinuxOptions: Option[SELinuxOptions] = None,
-      runAsUser: Option[Int] = None,
-      runAsGroup: Option[Int] = None,
-      runAsNonRoot: Option[Boolean] = None,
-      fsGroup: Option[Int] = None,
-      allowPrivilegeEscalation: Option[Boolean] = None
-  )
-    
-  type Capability=String    
+  type Capability = String
+
   case class Capabilities(
-      add:  List[Capability] = Nil, 
-      drop: List[Capability] = Nil)
-  
+                           add: List[Capability] = Nil,
+                           drop: List[Capability] = Nil)
+
   case class SELinuxOptions(
-      user: String = "",
-      role: String = "",
-      _type: String = "",
-      level: String = "")    
-      
-      
-}    
+                             user: String = "",
+                             role: String = "",
+                             _type: String = "",
+                             level: String = "")
+
+  case class Sysctl(
+                     name: String,
+                     value: String
+                   )
+
+}

--- a/client/src/test/resources/examplePodExtendedSpec.json
+++ b/client/src/test/resources/examplePodExtendedSpec.json
@@ -118,7 +118,6 @@
         },
         "securityContext": {
           "runAsUser": 1000,
-          "fsGroup": 2000,
           "allowPrivilegeEscalation": true
         }
       }

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -65,7 +65,7 @@ import Pod._
                                lifecycle=Some(Lifecycle(preStop=Some(ExecAction(List("/bin/bash", "probe"))))),
                                terminationMessagePath=Some("/var/log/termination-message"),
                                terminationMessagePolicy=Some(Container.TerminationMessagePolicy.File),
-                               securityContext=Some(Security.Context(capabilities=Some(Security.Capabilities(add=List("CAP_KILL"),drop=List("CAP_AUDIT_WRITE")))))
+                               securityContext=Some(SecurityContext(capabilities=Some(Security.Capabilities(add=List("CAP_KILL"),drop=List("CAP_AUDIT_WRITE")))))
                               )
                      )
       val vols = List(Volume("myVol1", Volume.Glusterfs("myEndpointsName", "/usr/mypath")),
@@ -74,7 +74,8 @@ import Pod._
                       volumes=vols,
                       dnsPolicy=DNSPolicy.ClusterFirst,
                       nodeSelector=Map("diskType" -> "ssd", "machineSize" -> "large"),
-                      imagePullSecrets=List(LocalObjectReference("abc"),LocalObjectReference("def"))
+                      imagePullSecrets=List(LocalObjectReference("abc"),LocalObjectReference("def")),
+                      securityContext=Some(PodSecurityContext(supplementalGroups=List(1, 2, 3)))
                      )
       val myPod = Namespace("myNamespace").pod("myPod",pdSpec)
                             
@@ -565,6 +566,7 @@ import Pod._
     val pod = Json.parse(podJsonStr).as[Pod]
 
     val container=pod.spec.get.containers(0)
+    container.securityContext.get.runAsUser mustEqual Some(1000)
     container.terminationMessagePolicy mustEqual Some(Container.TerminationMessagePolicy.FallbackToLogsOnError)
     container.terminationMessagePath mustEqual Some("/tmp/my-log")
     val mount=container.volumeMounts(0)


### PR DESCRIPTION
The security context is very different between [`PodSecurityContext`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#podsecuritycontext-v1-core) and [`SecurityContext` for containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#securitycontext-v1-core), so we should make them different.

I'm not sure if I should send this pull request after skuber `v2.1.0` is released. Please tell me if we should wait for it and rebase the branch of this PR.