### PR TITLE
Refactor patch objects

### DIFF
--- a/client/src/it/scala/skuber/PatchSpec.scala
+++ b/client/src/it/scala/skuber/PatchSpec.scala
@@ -88,12 +88,12 @@ class PatchSpec extends K8SFixture with Eventually with Matchers with BeforeAndA
   it should "patch a pod with json patch" in { k8s =>
     val randomString = java.util.UUID.randomUUID().toString
     val annotations = Map("skuber" -> "wow")
-    val patchData = JsonPatchOperationList(List(
+    val patchData = JsonPatch(List(
       JsonPatchOperation.Add("/metadata/labels/foo", randomString),
       JsonPatchOperation.Add("/metadata/annotations", randomString),
       JsonPatchOperation.Remove("/metadata/annotations"),
     ))
-    k8s.patch[JsonPatchOperationList, Pod](nginxPodName, patchData).map { _ =>
+    k8s.patch[JsonPatch, Pod](nginxPodName, patchData).map { _ =>
       eventually(timeout(10 seconds), interval(1 seconds)) {
         val retrievePod = k8s.get[Pod](nginxPodName)
         val podRetrieved = Await.ready(retrievePod, 2 seconds).value.get

--- a/client/src/main/scala/skuber/api/patch.scala
+++ b/client/src/main/scala/skuber/api/patch.scala
@@ -66,8 +66,16 @@ package object patch {
 
   case object JsonPatchStrategy extends PatchStrategy
 
-  case class JsonPatchOperationList(operations: List[JsonPatchOperation.Operation]) extends Patch {
+  case class JsonPatch(operations: List[JsonPatchOperation.Operation]) extends Patch {
     override val strategy = JsonPatchStrategy
+  }
+
+  trait JsonMergePatch extends Patch {
+    override val strategy = JsonMergePatchStrategy
+  }
+
+  trait StrategicMergePatch extends Patch {
+    override val strategy = StrategicMergePatchStrategy
   }
 
   case class MetadataPatch(labels: Option[Map[String, String]] = Some(Map()),

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -8,7 +8,7 @@ import org.apache.commons.codec.binary.Base64
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import skuber._
-import skuber.api.patch.{JsonPatchOperation, JsonPatchOperationList, MetadataPatch}
+import skuber.api.patch.{JsonPatchOperation, JsonPatch, MetadataPatch}
 
 /**
  * @author David O'Riordan
@@ -1118,7 +1118,7 @@ package object format {
     }))
   }
 
-  implicit def jsonPatchOperationListWrite = Writes[JsonPatchOperationList] { value =>
+  implicit def jsonPatchWrite = Writes[JsonPatch] { value =>
     JsArray(value.operations.map(jsonPatchOperationWrite.writes)) }
 
   implicit val metadataPatchWrite = Writes[MetadataPatch] { value =>


### PR DESCRIPTION
The change of this PR was originally included in https://github.com/doriordan/skuber/pull/237.

I think defining `JsonPatch`, `JsonMergePatch`, `StrategicMergePatch` is more intuitive for developers because the usage is the same as Kubernetes patch API option respectively.

Could you consider merging this change?