### PR TITLE
Fluent API for Job spec

### DIFF
--- a/client/src/main/scala/skuber/batch/Job.scala
+++ b/client/src/main/scala/skuber/batch/Job.scala
@@ -6,7 +6,7 @@ import skuber.{LabelSelector, NonCoreResourceSpecification, ObjectMeta, ObjectRe
 /**
   * @author Cory Klein
   */
-case class Job(val kind: String ="Job",
+case class Job(val kind: String = "Job",
                override val apiVersion: String = batchAPIVersion,
                val metadata: ObjectMeta = ObjectMeta(),
                spec: Option[Job.Spec] = None,
@@ -14,7 +14,11 @@ case class Job(val kind: String ="Job",
 
   lazy val copySpec: Job.Spec = this.spec.getOrElse(new Job.Spec())
 
-  def withTemplate(template: Pod.Template.Spec) = this.copy(spec=Some(copySpec.copy(template=Some(template))))
+  def withTemplate(template: Pod.Template.Spec) = this.copy(spec = Some(copySpec.copy(template = Some(template))))
+  def withParallelism(parallelism: Int) = this.copy(spec = Some(copySpec.copy(parallelism = Some(parallelism))))
+  def withCompletions(completions: Int) = this.copy(spec = Some(copySpec.copy(completions = Some(completions))))
+  def withActiveDeadlineSeconds(seconds: Int) = this.copy(spec = Some(copySpec.copy(activeDeadlineSeconds = Some(seconds))))
+  def withBackoffLimit(limit: Int) = this.copy(spec = Some(copySpec.copy(backoffLimit = Some(limit))))
 }
 
 object Job {

--- a/client/src/test/scala/skuber/batch/JobSpec.scala
+++ b/client/src/test/scala/skuber/batch/JobSpec.scala
@@ -20,6 +20,20 @@ class JobSpec extends Specification {
     job.spec.get.template.get mustEqual template
   }
 
+  "A Job object can be constructed with fluent API" >> {
+    val job = Job("jobname")
+      .withActiveDeadlineSeconds(42)
+      .withBackoffLimit(43)
+      .withCompletions(44)
+      .withParallelism(45)
+
+    job.spec.get.activeDeadlineSeconds mustEqual Some(42)
+    job.spec.get.backoffLimit mustEqual Some(43)
+    job.spec.get.completions mustEqual Some(44)
+    job.spec.get.parallelism mustEqual Some(45)
+  }
+
+
   "A Job object can be written to Json and then read back again successfully" >> {
     val container = Container(name = "jobcontainer", image = "jobimage")
     val template = Pod.Template.Spec.named("jobtemplatespecname").addContainer(container)


### PR DESCRIPTION
Currently there is a way to specify pod template for a job:
```scala
Job("my-job").withTemplate(podTemplate)
```
however there is no way to specify other job-specific settings (like a backoff limit or active deadline seconds), and client should write code like:
```scala
jobSpec = Job.Spec(backoffLimit = Some(2), template = Some(podTemplate))
k8s create Job("my-job").copy(spec = Some(jobSpec))
```

Aim of this change is to allow clients to use a fluent API to define a job-specific settings like:
```scala
k8s create Job("my-job")
      .withActiveDeadlineSeconds(3600)
      .withBackoffLimit(14)
      .withCompletions(7)
      .withParallelism(1)
```