### PR TITLE
Allow shareProcessNamespace in pod manifests

### DIFF
--- a/client/src/main/scala/skuber/Pod.scala
+++ b/client/src/main/scala/skuber/Pod.scala
@@ -50,8 +50,9 @@ object Pod {
     priorityClassName: Option[String] = None,
     schedulerName: Option[String] = None,
     subdomain: Option[String] = None,
-    dnsConfig: Option[DNSConfig] = None) {
-     
+    dnsConfig: Option[DNSConfig] = None,
+    shareProcessNamespace: Option[Boolean] = None) {
+
     // a few convenience methods for fluently building out a pod spec
     def addContainer(c: Container) = { this.copy(containers = c :: containers) }
     def addInitContainer(c: Container) = { this.copy(initContainers = c :: initContainers) }

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -792,7 +792,7 @@ package object format {
       (JsPath \ "securityContext").formatNullable[PodSecurityContext]
      ).tupled
 
-  val podSpecPartTwoFormat: OFormat[(Option[String], List[Pod.HostAlias], Option[Boolean], Option[Boolean], Option[Boolean], Option[Int], Option[String], Option[String], Option[String], Option[Pod.DNSConfig])] = (
+  val podSpecPartTwoFormat: OFormat[(Option[String], List[Pod.HostAlias], Option[Boolean], Option[Boolean], Option[Boolean], Option[Int], Option[String], Option[String], Option[String], Option[Pod.DNSConfig], Option[Boolean])] = (
       (JsPath \ "hostname").formatNullable[String] and
       (JsPath \ "hostAliases").formatMaybeEmptyList[Pod.HostAlias] and
       (JsPath \ "hostPID").formatNullable[Boolean] and
@@ -802,14 +802,15 @@ package object format {
       (JsPath \ "priorityClassName").formatNullable[String] and
       (JsPath \ "schedulerName").formatNullable[String] and
       (JsPath \ "subdomain").formatNullable[String] and
-      (JsPath \ "dnsConfig").formatNullable[Pod.DNSConfig]
+      (JsPath \ "dnsConfig").formatNullable[Pod.DNSConfig] and
+      (JsPath \ "shareProcessNamespace").formatNullable[Boolean]
   ).tupled
 
   implicit val podSpecFmt: Format[Pod.Spec] = (
       podSpecPartOneFormat and podSpecPartTwoFormat
   ).apply({
-    case ((conts, initConts, vols, rpol, tgps, adls, dnspol, nodesel, svcac, node, hnet, ips, aff, tol, psc), (host, aliases, pid, ipc, asat, prio, prioc, sched, subd, dnsc)) =>
-      Pod.Spec(conts, initConts, vols, rpol, tgps, adls, dnspol, nodesel, svcac, node, hnet, ips, aff, tol, psc, host, aliases, pid, ipc, asat, prio, prioc, sched, subd, dnsc)
+    case ((conts, initConts, vols, rpol, tgps, adls, dnspol, nodesel, svcac, node, hnet, ips, aff, tol, psc), (host, aliases, pid, ipc, asat, prio, prioc, sched, subd, dnsc, spn)) =>
+      Pod.Spec(conts, initConts, vols, rpol, tgps, adls, dnspol, nodesel, svcac, node, hnet, ips, aff, tol, psc, host, aliases, pid, ipc, asat, prio, prioc, sched, subd, dnsc, spn)
   }, s =>(
       ( s.containers,
         s.initContainers,
@@ -836,7 +837,8 @@ package object format {
         s.priorityClassName,
         s.schedulerName,
         s.subdomain,
-        s.dnsConfig
+        s.dnsConfig,
+        s.shareProcessNamespace
       ))
   )
     

--- a/client/src/test/resources/examplePodExtendedSpec.json
+++ b/client/src/test/resources/examplePodExtendedSpec.json
@@ -14,6 +14,7 @@
     "terminationGracePeriodSeconds": 60,
     "hostNetwork": true,
     "dnsPolicy": "None",
+    "shareProcessNamespace": true,
     "imagePullSecrets": [
       {
        "name": "secret"

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -648,6 +648,7 @@ import Pod._
     pod.spec.get.subdomain mustEqual Some("def")
     pod.spec.get.dnsPolicy mustEqual DNSPolicy.None
     pod.spec.get.hostNetwork mustEqual true
+    pod.spec.get.shareProcessNamespace mustEqual Some(true)
 
     // write and read it back in again and compare
     val json = Json.toJson(pod)


### PR DESCRIPTION
As of Kubernetes 1.12, `shareProcessNamespace` is available in pod manifests.
https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/

Could you merge this PR so we can use the flag through skuber?