### PR TITLE
Bugfix: conditions of job's status absent

### DIFF
--- a/client/src/main/scala/skuber/batch/Job.scala
+++ b/client/src/main/scala/skuber/batch/Job.scala
@@ -43,7 +43,7 @@ object Job {
                   template: Option[Pod.Template.Spec] = None,
                   backoffLimit: Option[Int] = None)
 
-  case class Status(conditions: Option[Condition] = None,
+  case class Status(conditions: List[Condition] = List(),
                     startTime: Option[Timestamp] = None,
                     completionTime: Option[Timestamp] = None,
                     active: Option[Int] = None,

--- a/client/src/main/scala/skuber/json/batch/format/package.scala
+++ b/client/src/main/scala/skuber/json/batch/format/package.scala
@@ -23,7 +23,7 @@ package object format {
     )(Job.Condition.apply _, unlift(Job.Condition.unapply))
 
   implicit val jobStatusFormat: Format[Job.Status] = (
-      (JsPath \ "conditions").formatNullable[Job.Condition] and
+      (JsPath \ "conditions").formatMaybeEmptyList[Job.Condition] and
       (JsPath \ "startTime").formatNullable[Timestamp] and
       (JsPath \ "completionTime").formatNullable[Timestamp] and
       (JsPath \ "active").formatNullable[Int] and

--- a/client/src/test/scala/skuber/batch/JobSpec.scala
+++ b/client/src/test/scala/skuber/batch/JobSpec.scala
@@ -95,13 +95,13 @@ class JobSpec extends Specification {
     container.name mustEqual "containername"
     container.image mustEqual "perl"
     val status = job.status.get
-    status.succeeded mustEqual Some(1)
-    status.active mustEqual Some(2)
+    status.active mustEqual Some(1)
+    status.succeeded mustEqual Some(2)
     status.failed mustEqual Some(3)
-    status.startTime mustEqual Some(parse("2019-02-01T11:43:05Z"))
-    val conditions = status.conditions.get
-    conditions.`type` mustEqual Some("Failed")
-    conditions.status mustEqual Some("True")
+    status.startTime mustEqual Some(parse("2019-02-01T11:42:19Z"))
+    val conditions = status.conditions.head
+    conditions.`type` mustEqual "Failed"
+    conditions.status mustEqual "True"
     conditions.lastProbeTime mustEqual Some(parse("2019-02-01T11:43:05Z"))
     conditions.lastTransitionTime mustEqual Some(parse("2019-02-01T11:43:05Z"))
     conditions.reason mustEqual Some("BackoffLimitExceeded")


### PR DESCRIPTION
**Current behaviour:** job's status `condition` section is not properly populated by skuber (all fields are `None` in every case) on requests like `k8s.get[Job]`

**Expected behaviour:** job's status `condition` section is reflecting actual state of k8s job

**Analysis**: `Job.Status` object definition is not in line with [k8s api (batch/v1)](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#jobstatus-v1-batch) where `conditions` field of `JobStatus` object is defined as an array.

**Fix** changed field type to match k8s API and dded test for this case