### PR TITLE
Correct example listing pods on Readme (removing parenthesis on k8sInit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This example lists pods in `kube-system` namespace:
   implicit val materializer = ActorMaterializer()
   implicit val dispatcher = system.dispatcher
 
-  val k8s = k8sInit()
+  val k8s = k8sInit
   val listPodsRequest = k8s.listInNamespace[PodList]("kube-system")
   listPodsRequest.onComplete {
     case Success(pods) => pods.items.foreach { p => println(p.name) }


### PR DESCRIPTION
When copy pasting the example in a scala console we get the following error:
```
scala> val k8s = k8sInit()
<console>:23: error: overloaded method value k8sInit with alternatives:
  (config: skuber.api.Configuration,appConfig: com.typesafe.config.Config)(implicit actorSystem: akka.actor.ActorSystem, implicit materializer: akka.stream.Materializer)skuber.api.client.KubernetesClient <and>
  (appConfig: com.typesafe.config.Config)(implicit actorSystem: akka.actor.ActorSystem, implicit materializer: akka.stream.Materializer)skuber.api.client.KubernetesClient <and>
  (config: skuber.api.Configuration)(implicit actorSystem: akka.actor.ActorSystem, implicit materializer: akka.stream.Materializer)skuber.api.client.KubernetesClient <and>
  (implicit actorSystem: akka.actor.ActorSystem,implicit materializer: akka.stream.Materializer)skuber.api.client.KubernetesClient
 cannot be applied to ()
       val k8s = k8sInit()
                 ^
```
Removing the parenthesis runs smoothly.