### PR TITLE
Persistent volume claim definition

### DIFF
--- a/client/src/main/scala/skuber/PersistentVolumeClaim.scala
+++ b/client/src/main/scala/skuber/PersistentVolumeClaim.scala
@@ -46,6 +46,7 @@ object PersistentVolumeClaim {
     volumeMode: VolumeMode.VolumeMode,
     resources: Option[Resource.Requirements] = None,
     storageClassName: Option[String] = None,
+    volumeName: Option[String] = None,
     selector: Option[Selector] = None
   )
 

--- a/client/src/main/scala/skuber/PersistentVolumeClaim.scala
+++ b/client/src/main/scala/skuber/PersistentVolumeClaim.scala
@@ -43,10 +43,10 @@ object PersistentVolumeClaim {
   import PersistentVolume.AccessMode
   case class Spec(
     accessModes: List[AccessMode.AccessMode] = Nil,
-    volumeMode: VolumeMode.VolumeMode,
     resources: Option[Resource.Requirements] = None,
-    storageClassName: Option[String] = None,
     volumeName: Option[String] = None,
+    storageClassName: Option[String] = None,
+    volumeMode: Option[VolumeMode.VolumeMode] = None,
     selector: Option[Selector] = None
   )
 

--- a/client/src/main/scala/skuber/PersistentVolumeClaim.scala
+++ b/client/src/main/scala/skuber/PersistentVolumeClaim.scala
@@ -1,47 +1,58 @@
 package skuber
 
-import java.util.Date
-
-import Volume._
+import skuber.annotation.MatchExpression
 
 /**
- * @author David O'Riordan
- */
+  * @author David O'Riordan
+  *
+  */
+
 case class PersistentVolumeClaim(
-    val kind: String ="PersistentVolumeClaim",
+    val kind: String = "PersistentVolumeClaim",
     override val apiVersion: String = v1,
     val metadata: ObjectMeta = ObjectMeta(),
     spec: Option[PersistentVolumeClaim.Spec] = None,
     status: Option[PersistentVolumeClaim.Status] = None)
-      extends ObjectResource {
-  
-  def withResourceVersion(version: String) = this.copy(metadata = metadata.copy(resourceVersion=version))
+  extends ObjectResource {
+
+  def withResourceVersion(version: String) = this.copy(metadata = metadata.copy(resourceVersion = version))
 
 }
-   
+
+case class Selector(matchLabels: Option[Map[String, String]] = None, matchExpressions: Option[List[MatchExpression]] = None)
+
 object PersistentVolumeClaim {
 
-  val specification=CoreResourceSpecification(
+  object VolumeMode extends Enumeration {
+    type VolumeMode = Value
+    val Filesystem, BlockVolume = Value
+  }
+
+  val specification = CoreResourceSpecification(
     scope = ResourceSpecification.Scope.Namespaced,
     names = ResourceSpecification.Names(
-      plural="persistentvolumeclaims",
-      singular="persistentvolumeclaim",
-      kind="PersistentVolumeClaim",
-      shortNames=List("pvc")
+      plural = "persistentvolumeclaims",
+      singular = "persistentvolumeclaim",
+      kind = "PersistentVolumeClaim",
+      shortNames = List("pvc")
     )
   )
-  implicit val pvcDef = new ResourceDefinition[PersistentVolumeClaim] { def spec=specification }
-  implicit val pvcListDef = new ResourceDefinition[PersistentVolumeClaimList] { def spec=specification }
+  implicit val pvcDef = new ResourceDefinition[PersistentVolumeClaim] { val spec = specification }
+  implicit val pvcListDef = new ResourceDefinition[PersistentVolumeClaimList] { val spec = specification }
 
   import PersistentVolume.AccessMode
   case class Spec(
-      accessModes: List[AccessMode.AccessMode] = Nil,
-      resources: Option[Resource.Requirements] = None,
-      volumeName: String="",
-      storageClassName: Option[String] = None)
-      
-  import PersistentVolume.Phase    
+    accessModes: List[AccessMode.AccessMode] = Nil,
+    volumeMode: VolumeMode.VolumeMode,
+    resources: Option[Resource.Requirements] = None,
+    storageClassName: Option[String] = None,
+    selector: Option[Selector] = None
+  )
+
+  import PersistentVolume.Phase
   case class Status(
-      phase: Option[Phase.Phase] = None,
-      accessModes: List[AccessMode.AccessMode] = List())
+    phase: Option[Phase.Phase] = None,
+    accessModes: List[AccessMode.AccessMode] = List()
+  )
+
 }

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -996,6 +996,7 @@ package object format {
       (JsPath \ "volumeMode").formatEnum(PersistentVolumeClaim.VolumeMode, Some(PersistentVolumeClaim.VolumeMode.Filesystem)) and
       (JsPath \ "resources").formatNullable[Resource.Requirements] and
       (JsPath \ "storageClassName").formatNullable[String] and
+      ((JsPath \ "volumeName").formatNullable[String]) and
       (JsPath \ "selector").formatNullable[Selector]
     )(PersistentVolumeClaim.Spec.apply _, unlift(PersistentVolumeClaim.Spec.unapply))
 
@@ -1004,7 +1005,12 @@ package object format {
       (JsPath \ "accessModes").formatMaybeEmptyList[PersistentVolume.AccessMode.AccessMode]
     )(PersistentVolumeClaim.Status.apply _, unlift(PersistentVolumeClaim.Status.unapply))
 
-  implicit val pvcFmt: Format[PersistentVolumeClaim] = Json.format[PersistentVolumeClaim]
+  implicit val pvcFmt: Format[PersistentVolumeClaim] =  (
+    objFormat and
+      (JsPath \ "spec").formatNullable[PersistentVolumeClaim.Spec] and
+      (JsPath \ "status").formatNullable[PersistentVolumeClaim.Status]
+    )(PersistentVolumeClaim.apply _, unlift(PersistentVolumeClaim.unapply))
+
 
   implicit val configMapFmt: Format[ConfigMap] = (
     objFormat and

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -9,7 +9,8 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import skuber.Volume.{ConfigMapVolumeSource, KeyToPath}
 import skuber._
-import skuber.api.patch.{JsonPatchOperation, JsonPatch, MetadataPatch}
+import skuber.annotation.MatchExpression
+import skuber.api.patch.{JsonPatch, JsonPatchOperation, MetadataPatch}
 
 /**
  * @author David O'Riordan
@@ -986,24 +987,24 @@ package object format {
     (JsPath \ "spec").formatNullable[PersistentVolume.Spec] and
     (JsPath \ "status").formatNullable[PersistentVolume.Status]
   )(PersistentVolume.apply _, unlift(PersistentVolume.unapply))
-  
+
+  import skuber.json.annotation.format.matchExpressionFormat
+  implicit val selectorFmt: Format[Selector] = Json.format[Selector]
+
   implicit val pvClaimSpecFmt: Format[PersistentVolumeClaim.Spec] = (
     (JsPath \ "accessModes").formatMaybeEmptyList[PersistentVolume.AccessMode.AccessMode] and
-    (JsPath \ "resources").formatNullable[Resource.Requirements] and
-    (JsPath \ "volumeName").formatMaybeEmptyString() and
-    (JsPath \ "storageClassName").formatNullable[String]
-  )(PersistentVolumeClaim.Spec.apply _, unlift(PersistentVolumeClaim.Spec.unapply))
-  
+      (JsPath \ "volumeMode").formatEnum(PersistentVolumeClaim.VolumeMode, Some(PersistentVolumeClaim.VolumeMode.Filesystem)) and
+      (JsPath \ "resources").formatNullable[Resource.Requirements] and
+      (JsPath \ "storageClassName").formatNullable[String] and
+      (JsPath \ "selector").formatNullable[Selector]
+    )(PersistentVolumeClaim.Spec.apply _, unlift(PersistentVolumeClaim.Spec.unapply))
+
   implicit val pvClaimStatusFmt: Format[PersistentVolumeClaim.Status] = (
     (JsPath \ "phase").formatNullableEnum(PersistentVolume.Phase) and
-    (JsPath \ "accessModes").formatMaybeEmptyList[PersistentVolume.AccessMode.AccessMode]
-  )(PersistentVolumeClaim.Status.apply _, unlift(PersistentVolumeClaim.Status.unapply))
-  
-  implicit val pvClaimFmt: Format[PersistentVolumeClaim] = (
-    objFormat and
-    (JsPath \ "spec").formatNullable[PersistentVolumeClaim.Spec] and
-    (JsPath \ "status").formatNullable[PersistentVolumeClaim.Status]
-  )(PersistentVolumeClaim.apply _, unlift(PersistentVolumeClaim.unapply))
+      (JsPath \ "accessModes").formatMaybeEmptyList[PersistentVolume.AccessMode.AccessMode]
+    )(PersistentVolumeClaim.Status.apply _, unlift(PersistentVolumeClaim.Status.unapply))
+
+  implicit val pvcFmt: Format[PersistentVolumeClaim] = Json.format[PersistentVolumeClaim]
 
   implicit val configMapFmt: Format[ConfigMap] = (
     objFormat and

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -993,10 +993,10 @@ package object format {
 
   implicit val pvClaimSpecFmt: Format[PersistentVolumeClaim.Spec] = (
     (JsPath \ "accessModes").formatMaybeEmptyList[PersistentVolume.AccessMode.AccessMode] and
-      (JsPath \ "volumeMode").formatEnum(PersistentVolumeClaim.VolumeMode, Some(PersistentVolumeClaim.VolumeMode.Filesystem)) and
       (JsPath \ "resources").formatNullable[Resource.Requirements] and
-      (JsPath \ "storageClassName").formatNullable[String] and
       ((JsPath \ "volumeName").formatNullable[String]) and
+      (JsPath \ "storageClassName").formatNullable[String] and
+      (JsPath \ "volumeMode").formatNullableEnum(PersistentVolumeClaim.VolumeMode) and
       (JsPath \ "selector").formatNullable[Selector]
     )(PersistentVolumeClaim.Spec.apply _, unlift(PersistentVolumeClaim.Spec.unapply))
 

--- a/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
@@ -28,6 +28,7 @@ class VolumeReadWriteSpec extends Specification {
           volumeMode = VolumeMode.Filesystem,
           resources=Some(Resource.Requirements(limits=Map("storage" -> "30Gi"))),
           storageClassName = Some("a-storage-class-name"),
+          volumeName = Some("volume-name"),
           selector = Some(Selector(matchLabels = Some(Map("label" -> "value")), matchExpressions = None))
         ))
       )

--- a/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
@@ -5,8 +5,9 @@ import org.specs2.mutable.Specification
 import play.api.libs.json._
 import skuber._
 import skuber.json.format._
-
 import scala.io.Source
+
+import skuber.PersistentVolumeClaim.VolumeMode
 
 /**
  * @author David O'Riordan
@@ -24,8 +25,10 @@ class VolumeReadWriteSpec extends Specification {
         ),
         spec = Some(PersistentVolumeClaim.Spec(
           accessModes = List(PersistentVolume.AccessMode.ReadWriteOnce),
+          volumeMode = VolumeMode.Filesystem,
+          resources=Some(Resource.Requirements(limits=Map("storage" -> "30Gi"))),
           storageClassName = Some("a-storage-class-name"),
-          resources=Some(Resource.Requirements(limits=Map("storage" -> "30Gi")))
+          selector = Some(Selector(matchLabels = Some(Map("label" -> "value")), matchExpressions = None))
         ))
       )
       val pvcJson = Json.toJson(pvc)

--- a/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
@@ -25,10 +25,10 @@ class VolumeReadWriteSpec extends Specification {
         ),
         spec = Some(PersistentVolumeClaim.Spec(
           accessModes = List(PersistentVolume.AccessMode.ReadWriteOnce),
-          volumeMode = VolumeMode.Filesystem,
-          resources=Some(Resource.Requirements(limits=Map("storage" -> "30Gi"))),
-          storageClassName = Some("a-storage-class-name"),
+          resources = Some(Resource.Requirements(limits=Map("storage" -> "30Gi"))),
           volumeName = Some("volume-name"),
+          storageClassName = Some("a-storage-class-name"),
+          volumeMode = Some(VolumeMode.Filesystem),
           selector = Some(Selector(matchLabels = Some(Map("label" -> "value")), matchExpressions = None))
         ))
       )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.0.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.0.1


### PR DESCRIPTION
This PR updates the existing implementation of PersistentVolumeClaims add support for: 

-selectors
-volumeMode

As defined in the Kubernetes (1.11 specification)[https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#persistentvolumeclaim-v1-core]

Closes https://github.com/doriordan/skuber/issues/261