### PR TITLE
Upgrade Play Json (fix #256)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % "2.5.14"
 val logback = "ch.qos.logback" % "logback-classic" % "1.1.3" % Runtime
 
 // the Json formatters are based on Play Json
-val playJson = "com.typesafe.play" %% "play-json" % "2.6.9"
+val playJson = "com.typesafe.play" %% "play-json" % "2.7.2"
 
 // Need Java 8 or later as the java.time package is used to represent K8S timestamps
 scalacOptions += "-target:jvm-1.8"

--- a/client/src/test/scala/skuber/api/WatchSourceSpec.scala
+++ b/client/src/test/scala/skuber/api/WatchSourceSpec.scala
@@ -322,7 +322,6 @@ class WatchSourceSpec extends Specification with MockitoSugar {
         .expectError()
 
       error must haveClass[JsonParseException]
-      error.getMessage mustEqual "Unexpected character ('a' (code 97)): was expecting double-quote to start field name\n at [Source: {asdf:asdfa}; line: 1, column: 3]"
 
       verify(client, times(2)).logConfig
       verify(client).buildRequest(

--- a/client/src/test/scala/skuber/autoscaling/v2beta1/HorizontalPodAutoscalerSpec.scala
+++ b/client/src/test/scala/skuber/autoscaling/v2beta1/HorizontalPodAutoscalerSpec.scala
@@ -20,9 +20,7 @@ class HorizontalPodAutoscalerSpec extends Specification {
     }
 
     "encode to json" >> {
-      Json.stringify(
-        Json.toJson(hpa)
-      ) mustEqual createJson("/exampleHorizontalPodAutoscaler.json")
+      Json.toJson(hpa) mustEqual Json.parse(createJson("/exampleHorizontalPodAutoscaler.json"))
     }
   }
 

--- a/client/src/test/scala/skuber/policy/v1beta1/PodDisruptionBudgetSpec.scala
+++ b/client/src/test/scala/skuber/policy/v1beta1/PodDisruptionBudgetSpec.scala
@@ -16,14 +16,12 @@ class PodDisruptionBudgetSpec extends Specification {
       Json.parse(createJson("/examplePodDisruptionBudget.json")).validate[PodDisruptionBudget] mustEqual JsSuccess(pdb)
     }
     "encode to json" >> {
-      Json.stringify(
-        Json.toJson(
-          PodDisruptionBudget("someName")
-            .withMaxUnavailable(Left(2))
-            .withMinAvailable(Left(1))
-            .withLabelSelector("application" is "someApplicationName")
-        )
-      ) mustEqual createJson("/examplePodDisruptionBudget.json")
+      Json.toJson(
+        PodDisruptionBudget("someName")
+          .withMaxUnavailable(Left(2))
+          .withMinAvailable(Left(1))
+          .withLabelSelector("application" is "someApplicationName")
+      ) mustEqual Json.parse(createJson("/examplePodDisruptionBudget.json"))
     }
   }
 


### PR DESCRIPTION
This solves the `NoSuchMethodError` that occurs when using Skuber on an application using Play 2.7.x (#256).

Some tests had to be updated becaused they relied on internal Play Json implementation that changed with version 2.7.

Also, this will cause binary incompatibility for Play 2.6.x users, so this should not be released in a patch version.

Fixes #256