### PR TITLE
Fixes #272

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 language: scala
 scala:
-- 2.11.8
-jdk:
-- oraclejdk8
+- 2.12.8
 cache:
   directories:
     - '$HOME/.ivy2/cache'

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,13 @@
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
+val akkaVersion = "2.5.23"
+
 val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
 val specs2 = "org.specs2" %% "specs2-core" % "4.3.2"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
 val mockito = "org.mockito" % "mockito-core" % "2.21.0"
-val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.14"
+val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion
 
 val snakeYaml =  "org.yaml" % "snakeyaml" % "1.21"
 val commonsIO = "commons-io" % "commons-io" % "2.6"
@@ -14,11 +16,11 @@ val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % "1.60"
 
 // the client API request/response handing uses Akka Http 
 val akkaHttp = "com.typesafe.akka" %% "akka-http" % "10.1.3"
-val akkaStream = "com.typesafe.akka" %% "akka-stream" % "2.5.14"
-val akka = "com.typesafe.akka" %% "akka-actor" % "2.5.14"
+val akkaStream = "com.typesafe.akka" %% "akka-stream" % akkaVersion
+val akka = "com.typesafe.akka" %% "akka-actor" % akkaVersion
 
 // Skuber uses akka logging, so the examples config uses the akka slf4j logger with logback backend
-val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % "2.5.14"
+val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
 val logback = "ch.qos.logback" % "logback-classic" % "1.1.3" % Runtime
 
 // the Json formatters are based on Play Json
@@ -29,7 +31,7 @@ scalacOptions += "-target:jvm-1.8"
 
 scalacOptions in Test ++= Seq("-Yrangepos")
 
-version in ThisBuild := "2.2.0"
+version in ThisBuild := "2.3.0"
 
 sonatypeProfileName := "io.skuber"
 

--- a/client/src/main/scala/skuber/api/client/package.scala
+++ b/client/src/main/scala/skuber/api/client/package.scala
@@ -3,8 +3,8 @@ package skuber.api
 import java.time.Instant
 import java.util.UUID
 
-import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
@@ -23,7 +23,13 @@ import skuber.api.client.impl.KubernetesClientImpl
   */
 package object client {
 
-  type Pool[T] = Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed]
+  /**
+    * The materialized value is an optional host connection pool.
+    * For testing, allows mocking without creating a host connection pool.
+    * For development and production, provides access to the host connection pool created (if none was provided).
+    * @tparam T The type of elements flowing in and out.
+    */
+  type Pool[T] = Flow[(HttpRequest, T), (Try[HttpResponse], T), Option[Http.HostConnectionPool]]
 
   final val sysProps = new SystemProperties
 

--- a/client/src/main/scala/skuber/api/watch/LongPollingPool.scala
+++ b/client/src/main/scala/skuber/api/watch/LongPollingPool.scala
@@ -1,6 +1,5 @@
 package skuber.api.watch
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
 import akka.http.scaladsl.{Http, HttpsConnectionContext}
@@ -19,19 +18,19 @@ private[api] object LongPollingPool {
         Http().newHostConnectionPool[T](
           host, port,
           buildHostConnectionPool(poolIdleTimeout, clientConnectionSettings, system)
-        ).mapMaterializedValue(_ => NotUsed)
+        ).mapMaterializedValue(Some(_))
       case "https" =>
         Http().newHostConnectionPoolHttps[T](
           host, port,
           httpsConnectionContext.getOrElse(Http().defaultClientHttpsContext),
           buildHostConnectionPool(poolIdleTimeout, clientConnectionSettings, system)
-        ).mapMaterializedValue(_ => NotUsed)
+        ).mapMaterializedValue(Some(_))
       case unsupported =>
         throw new IllegalArgumentException(s"Schema $unsupported is not supported")
     }
   }
 
-  private def buildHostConnectionPool[T](poolIdleTimeout: Duration, clientConnectionSettings: ClientConnectionSettings, system: ActorSystem) = {
+  def buildHostConnectionPool[T](poolIdleTimeout: Duration, clientConnectionSettings: ClientConnectionSettings, system: ActorSystem) = {
     ConnectionPoolSettings(system)
       .withMaxConnections(1)              // Limit number the of open connections to one
       .withPipeliningLimit(1)             // Limit pipelining of requests to one

--- a/client/src/main/scala/skuber/api/watch/WatchSource.scala
+++ b/client/src/main/scala/skuber/api/watch/WatchSource.scala
@@ -2,32 +2,35 @@ package skuber.api.watch
 
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
-import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge, Source}
+import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Keep, Merge, Source}
 import akka.stream.{Materializer, SourceShape}
 import play.api.libs.json.Format
 import skuber.api.client._
 import skuber.api.client.impl.KubernetesClientImpl
-import skuber.{K8SRequestContext, ObjectResource, ResourceDefinition, ListOptions}
+import skuber.{ListOptions, ObjectResource, ResourceDefinition}
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
-private[api] object WatchSource {
-  sealed trait StreamElement[O <: ObjectResource] {}
-  case class End[O <: ObjectResource]() extends StreamElement[O]
+/**
+  * @author David O'Riordan
+  */
+object WatchSource {
+  private[api] sealed trait StreamElement[O <: ObjectResource] {}
+  private[api] case class End[O <: ObjectResource]() extends StreamElement[O]
   case class Start[O <: ObjectResource](resourceVersion: Option[String]) extends StreamElement[O]
-  case class Result[O <: ObjectResource](resourceVersion: String, value: WatchEvent[O]) extends StreamElement[O]
+  private[api] case class Result[O <: ObjectResource](resourceVersion: String, value: WatchEvent[O]) extends StreamElement[O]
 
-  sealed trait StreamState {}
-  case object Waiting extends StreamState
-  case object Processing extends StreamState
-  case object Finished extends StreamState
+  private[api] sealed trait StreamState {}
+  private[api] case object Waiting extends StreamState
+  private[api] case object Processing extends StreamState
+  private[api] case object Finished extends StreamState
 
-  case class StreamContext(currentResourceVersion: Option[String], state: StreamState)
+  private[api] case class StreamContext(currentResourceVersion: Option[String], state: StreamState)
 
-  def apply[O <: ObjectResource](client: KubernetesClientImpl,
+  private[api] def apply[O <: ObjectResource](client: KubernetesClientImpl,
                                  pool: Pool[Start[O]],
                                  name: Option[String],
                                  options: ListOptions,
@@ -35,76 +38,78 @@ private[api] object WatchSource {
                                                fm: Materializer,
                                                format: Format[O],
                                                rd: ResourceDefinition[O],
-                                               lc: LoggingContext): Source[WatchEvent[O], NotUsed] = {
-    Source.fromGraph(GraphDSL.create() { implicit b =>
-      import GraphDSL.Implicits._
+                                               lc: LoggingContext): Source[WatchEvent[O], (Pool[WatchSource.Start[O]], Option[Http.HostConnectionPool])] = {
 
-      implicit val dispatcher: ExecutionContext = sys.dispatcher
+    implicit val dispatcher: ExecutionContext = sys.dispatcher
 
-      def createWatchRequest(since: Option[String]) =
-      {
-        val nameFieldSelector=name.map(objName => s"metadata.name=$objName")
-        val watchOptions=options.copy(
-          resourceVersion = since,
-          watch = Some(true),
-          fieldSelector = nameFieldSelector.orElse(options.fieldSelector)
-        )
-        client.buildRequest(
-          HttpMethods.GET, rd, None, query =  Some(Uri.Query(watchOptions.asMap))
-        )
+    val singleEnd = Source.single(End[O]())
+
+    def singleStart(s:StreamElement[O]) = Source.single(s)
+
+    val httpFlow: Flow[(HttpRequest, Start[O]), StreamElement[O], Option[Http.HostConnectionPool]] =
+      Flow[(HttpRequest, Start[O])].map { request => // log request
+        client.logInfo(client.logConfig.logRequestBasic, s"about to send HTTP request: ${request._1.method.value} ${request._1.uri.toString}")
+        request
+      }.viaMat[(Try[HttpResponse], Start[O]), Option[Http.HostConnectionPool], Option[Http.HostConnectionPool]](pool)(Keep.right).flatMapConcat {
+        case (Success(HttpResponse(StatusCodes.OK, _, entity, _)), se) =>
+          client.logInfo(client.logConfig.logResponseBasic, s"received response with HTTP status 200")
+          singleStart(se).concat(
+            BytesToWatchEventSource[O](entity.dataBytes, bufSize).map { event =>
+              Result[O](event._object.resourceVersion, event)
+            }
+          ).concat(singleEnd)
+        case (Success(HttpResponse(sc, _, entity, _)), _) =>
+          client.logWarn(s"Error watching resource. Received a status of ${sc.intValue()}")
+          entity.discardBytes()
+          throw new K8SException(Status(message = Some("Error watching resource"), code = Some(sc.intValue())))
+        case (Failure(f), _) =>
+          client.logError("Error watching resource.", f)
+          throw new K8SException(Status(message = Some("Error watching resource"), details = Some(f.getMessage)))
       }
 
-      val singleEnd = Source.single(End[O]())
+    val httpFlowMat: Flow[(HttpRequest, Start[O]), StreamElement[O], (Pool[WatchSource.Start[O]], Option[Http.HostConnectionPool])] =
+      httpFlow.mapMaterializedValue { pool -> _ }
 
-      def singleStart(s:StreamElement[O]) = Source.single(s)
-
-      val initSource = Source.single(
-        (createWatchRequest(options.resourceVersion), Start[O](options.resourceVersion))
+    def createWatchRequest(since: Option[String]) =
+    {
+      val nameFieldSelector=name.map(objName => s"metadata.name=$objName")
+      val watchOptions=options.copy(
+        resourceVersion = since,
+        watch = Some(true),
+        fieldSelector = nameFieldSelector.orElse(options.fieldSelector)
       )
+      client.buildRequest(
+        HttpMethods.GET, rd, None, query =  Some(Uri.Query(watchOptions.asMap))
+      )
+    }
 
-      val httpFlow: Flow[(HttpRequest, Start[O]), StreamElement[O], NotUsed] =
-        Flow[(HttpRequest, Start[O])].map { request => // log request
-          client.logInfo(client.logConfig.logRequestBasic, s"about to send HTTP request: ${request._1.method.value} ${request._1.uri.toString}")
-          request
-        }.via(pool).flatMapConcat {
-          case (Success(HttpResponse(StatusCodes.OK, _, entity, _)), se) =>
-            client.logInfo(client.logConfig.logResponseBasic, s"received response with HTTP status 200")
-            singleStart(se).concat(
-              BytesToWatchEventSource[O](entity.dataBytes, bufSize).map { event =>
-                Result[O](event._object.resourceVersion, event)
-              }
-            ).concat(singleEnd)
-          case (Success(HttpResponse(sc, _, entity, _)), _) =>
-            client.logWarn(s"Error watching resource. Received a status of ${sc.intValue()}")
-            entity.discardBytes()
-            throw new K8SException(Status(message = Some("Error watching resource"), code = Some(sc.intValue())))
-          case (Failure(f), _) =>
-            client.logError("Error watching resource.", f)
-            throw new K8SException(Status(message = Some("Error watching resource"), details = Some(f.getMessage)))
+    val initSource = Source.single(
+      (createWatchRequest(options.resourceVersion), Start[O](options.resourceVersion))
+    )
+
+    val outboundFlow: Flow[StreamElement[O], WatchEvent[O], NotUsed] =
+      Flow[StreamElement[O]]
+        .filter(_.isInstanceOf[Result[O]])
+        .map{
+          case Result(_, event) => event
+          case _ => throw new K8SException(Status(message = Some("Error processing watch events.")))
         }
 
-      val outboundFlow: Flow[StreamElement[O], WatchEvent[O], NotUsed] =
-        Flow[StreamElement[O]]
-          .filter(_.isInstanceOf[Result[O]])
-          .map{
-            case Result(_, event) => event
-            case _ => throw new K8SException(Status(message = Some("Error processing watch events.")))
-          }
-
-
-      val feedbackFlow: Flow[StreamElement[O], (HttpRequest, Start[O]), NotUsed] =
-        Flow[StreamElement[O]].scan(StreamContext(None, Waiting)){(cxt, next) =>
-          next match {
-            case Start(rv) => StreamContext(rv, Processing)
-            case Result(rv, _) => StreamContext(Some(rv), Processing)
-            case End() => cxt.copy(state = Finished)
-          }
-        }.filter(_.state == Finished).map { acc =>
-          (createWatchRequest(acc.currentResourceVersion), Start[O](acc.currentResourceVersion))
+    val feedbackFlow: Flow[StreamElement[O], (HttpRequest, Start[O]), NotUsed] =
+      Flow[StreamElement[O]].scan(StreamContext(None, Waiting)){(cxt, next) =>
+        next match {
+          case Start(rv) => StreamContext(rv, Processing)
+          case Result(rv, _) => StreamContext(Some(rv), Processing)
+          case End() => cxt.copy(state = Finished)
         }
+      }.filter(_.state == Finished).map { acc =>
+        (createWatchRequest(acc.currentResourceVersion), Start[O](acc.currentResourceVersion))
+      }
+
+    Source.fromGraph(GraphDSL.create(httpFlowMat) { implicit b => http =>
+      import GraphDSL.Implicits._
 
       val init = b.add(initSource)
-      val http = b.add(httpFlow)
       val merge = b.add(Merge[(HttpRequest, Start[O])](2))
       val broadcast = b.add(Broadcast[StreamElement[O]](2, eagerCancel = true))
       val outbound = b.add(outboundFlow)

--- a/client/src/test/scala/skuber/api/WatchSourceSpec.scala
+++ b/client/src/test/scala/skuber/api/WatchSourceSpec.scala
@@ -4,6 +4,7 @@ import java.net.ConnectException
 import java.time.{ZoneId, ZonedDateTime}
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.Framing.FramingException
 import akka.stream.scaladsl.{Flow, Keep, TcpIdleTimeoutException}
@@ -517,13 +518,13 @@ class WatchSourceSpec extends Specification with MockitoSugar {
   def mockPool[O <: ObjectResource](requestResponses: Map[HttpRequest, HttpResponse]): Pool[Start[O]] = {
     Flow[(HttpRequest, Start[O])].map { x =>
       (Try(requestResponses(x._1)), x._2)
-    }
+    }.mapMaterializedValue(_ => Option.empty[Http.HostConnectionPool])
   }
 
   def mockPool[O <: ObjectResource](error: Throwable): Pool[Start[O]] = {
     Flow[(HttpRequest, Start[O])].map { x =>
       (Try(throw error), x._2)
-    }
+    }.mapMaterializedValue(_ => Option.empty[Http.HostConnectionPool])
   }
 
   def retrieveWatchJson(path: String): String = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.2.8


### PR DESCRIPTION
With the fix, the example in the issue produces the following behavior:

```
[INFO] [05/06/2019 10:08:13.366] [main] [skuber.api] Using following context for connecting to Kubernetes cluster: Context(Cluster(v1,https://192.168.99.100:8443,false,Some(Left(/home/rouquett/.minikube/ca.crt))),CertAuth(clientCertificate=/home/rouquett/.minikube/client.crt clientKey=/home/rouquett/.minikube/client.key userName= ),Namespace(Namespace,v1,ObjectMeta(default,,,,,,None,None,None,Map(),Map(),List(),0,None,None),None,None))
[INFO] [05/06/2019 10:08:14.128] [KubeJobSystem-akka.actor.default-dispatcher-2] [skuber.api] [ { reqId=aa257631-a6b5-4360-ad7c-3adef1474cb8} } - about to send HTTP request: POST https://192.168.99.100:8443/apis/batch/v1/namespaces/default/jobs]
[INFO] [05/06/2019 10:08:14.435] [KubeJobSystem-akka.actor.default-dispatcher-2] [skuber.api] [ { reqId=aa257631-a6b5-4360-ad7c-3adef1474cb8} } - received response with HTTP status 201]
[INFO] [05/06/2019 10:08:17.515] [KubeJobSystem-akka.actor.default-dispatcher-12] [skuber.api] [ { reqId=544dd3c6-dc6d-43e3-90da-66342c8b173b} } - about to send HTTP request: GET https://192.168.99.100:8443/apis/batch/v1/namespaces/default/jobs/pi-0262cfe4-74a2-4440-9307-356e92ff8400]
[INFO] [05/06/2019 10:08:17.543] [KubeJobSystem-akka.actor.default-dispatcher-5] [skuber.api] [ { reqId=544dd3c6-dc6d-43e3-90da-66342c8b173b} } - received response with HTTP status 200]
[INFO] [05/06/2019 10:08:20.564] [KubeJobSystem-akka.actor.default-dispatcher-12] [skuber.api] [ { reqId=be225dc9-3d77-4f67-8f61-c4e67f8bfe7c} } - about to send HTTP request: GET https://192.168.99.100:8443/apis/batch/v1/namespaces/default/jobs/pi-0262cfe4-74a2-4440-9307-356e92ff8400]
[INFO] [05/06/2019 10:08:20.587] [KubeJobSystem-akka.actor.default-dispatcher-12] [skuber.api] [ { reqId=be225dc9-3d77-4f67-8f61-c4e67f8bfe7c} } - received response with HTTP status 200]
[INFO] [05/06/2019 10:08:23.604] [KubeJobSystem-akka.actor.default-dispatcher-3] [skuber.api] [ { reqId=d748bf19-6c30-44e0-9ad4-528c933782a7} } - about to send HTTP request: GET https://192.168.99.100:8443/apis/batch/v1/namespaces/default/jobs/pi-0262cfe4-74a2-4440-9307-356e92ff8400]
[INFO] [05/06/2019 10:08:23.630] [KubeJobSystem-akka.actor.default-dispatcher-5] [skuber.api] [ { reqId=d748bf19-6c30-44e0-9ad4-528c933782a7} } - received response with HTTP status 200]
[INFO] [05/06/2019 10:08:26.654] [KubeJobSystem-akka.actor.default-dispatcher-4] [skuber.api] [ { reqId=d820ef81-c0c4-4de6-93ed-5e796e87931f} } - about to send HTTP request: GET https://192.168.99.100:8443/apis/batch/v1/namespaces/default/jobs/pi-0262cfe4-74a2-4440-9307-356e92ff8400]
[INFO] [05/06/2019 10:08:26.681] [KubeJobSystem-akka.actor.default-dispatcher-5] [skuber.api] [ { reqId=d820ef81-c0c4-4de6-93ed-5e796e87931f} } - received response with HTTP status 200]
[INFO] [05/06/2019 10:08:26.688] [KubeJobSystem-akka.actor.default-dispatcher-3] [akka://KubeJobSystem/user/main/KubeJob] Success: 2019-05-06T17:08:24Z
[INFO] [05/06/2019 10:08:26.690] [KubeJobSystem-akka.actor.default-dispatcher-4] [akka://KubeJobSystem/user/main] Terminated: Actor[akka://KubeJobSystem/user/main/KubeJob#841428984]
[INFO] [05/06/2019 10:08:26.691] [KubeJobSystem-akka.actor.default-dispatcher-4] [akka://KubeJobSystem/user/main] Terminate!
```

Clean shutdown, no warnings, no errors.
