### PR TITLE
Fix time writes typo

### DIFF
--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -20,8 +20,10 @@ package object format {
   
   // Formatters for the Java 8 ZonedDateTime objects that represent
   // (ISO 8601 / RFC 3329 compatible) Kubernetes timestamp fields 
-  implicit val timewWrites = Writes.temporalWrites[ZonedDateTime, DateTimeFormatter](
+  implicit val timeWrites = Writes.temporalWrites[ZonedDateTime, DateTimeFormatter](
       DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+  @deprecated("Use timeWrites instead", "2.3.0")
+  def timewWrites = timeWrites
   implicit val timeReads = Reads.DefaultZonedDateTimeReads    
       
   // Many Kubernetes fields are interpreted as "empty" if they have certain values:


### PR DESCRIPTION
Fixed typo in skuber.json.format.timeWrites.

This change is binary backwards compatible, but may not be source backwards compatible, since if someone explicitly imported `skuber.json.format.timewWrites`, since it's no longer implicit, it won't be in scope. However, if they imported `skuber.json.format._`, then everything should still work.