### PR TITLE
More GCP fixes

### DIFF
--- a/client/src/test/scala/skuber/model/AuthSpec.scala
+++ b/client/src/test/scala/skuber/model/AuthSpec.scala
@@ -41,7 +41,7 @@ class AuthSpec extends Specification {
   }
 
   "GcpAuth toString masks accessToken" >> {
-    GcpAuth(accessToken = "MyAccessToken", expiry = Instant.now, cmdPath = "gcp", cmdArgs = "").toString mustEqual
+    GcpAuth(accessToken = Some("MyAccessToken"), expiry = Some(Instant.now), cmdPath = "gcp", cmdArgs = "").toString mustEqual
       "GcpAuth(accessToken=<redacted>)"
   }
 


### PR DESCRIPTION
This fixes two issues with gcp auth providers.

Firstly, a gcp auth provider can have no accessToken. I don't know if that's new or not.

Secondly, all the dates in my kube config file changed format, I don't know what changed them, if it was a new kubectl version, a new gcloud version, or something else. So, I added a date format for it.

* Allow parsing dates with odd format
* Allow there to be no access token