### PR TITLE
Make access-token and expiry optional in kubeconfig

### DIFF
--- a/client/src/main/scala/skuber/api/Configuration.scala
+++ b/client/src/main/scala/skuber/api/Configuration.scala
@@ -115,12 +115,11 @@ object Configuration {
         def valueAt[T](parent: YamlMap, key: String, fallback: Option[T] = None) : T =
           parent.asScala.get(key).orElse(fallback).get.asInstanceOf[T]
 
-        def instantValueAt[T](parent: YamlMap, key: String) : Instant =
-          parent.asScala.get(key) match {
-            case Some(d: Date) => d.toInstant
-            case Some(s: String) => parseInstant(s)
-            case Some(unsupported) => sys.error(s"Unsupported date type: $unsupported")
-            case None => sys.error(s"No value found at $key")
+        def instantValueAt[T](parent: YamlMap, key: String) : Option[Instant] =
+          parent.asScala.get(key).map {
+            case d: Date => d.toInstant
+            case s: String => parseInstant(s)
+            case unsupported => sys.error(s"Unsupported date type: $unsupported")
           }
 
         def optionalValueAt[T](parent: YamlMap, key: String) : Option[T] =
@@ -175,7 +174,7 @@ object Configuration {
               case "gcp" =>
                 Some(
                   GcpAuth(
-                    accessToken = valueAt(config, "access-token"),
+                    accessToken = optionalValueAt(config, "access-token"),
                     expiry = instantValueAt(config, "expiry"),
                     cmdPath = valueAt(config, "cmd-path"),
                     cmdArgs = valueAt(config, "cmd-args")

--- a/client/src/main/scala/skuber/api/client/package.scala
+++ b/client/src/main/scala/skuber/api/client/package.scala
@@ -151,7 +151,7 @@ package object client {
     def apply(accessToken: Option[String], expiry: Option[Instant], cmdPath: String, cmdArgs: String): GcpAuth =
       new GcpAuth(
         GcpConfiguration(
-          refresh = accessToken.zip(expiry).map(GcpConfiguredRefresh.tupled),
+          refresh = accessToken.zip(expiry).map(GcpConfiguredRefresh.tupled).headOption,
           cmd = GcpCommand(cmdPath, cmdArgs)
         )
       )

--- a/client/src/test/scala/skuber/model/AuthSpec.scala
+++ b/client/src/test/scala/skuber/model/AuthSpec.scala
@@ -41,7 +41,7 @@ class AuthSpec extends Specification {
   }
 
   "GcpAuth toString masks accessToken" >> {
-    GcpAuth(accessToken = "MyAccessToken", expiry = Instant.now, cmdPath = "gcp", cmdArgs = "").toString mustEqual
+    GcpAuth(accessToken = Some("MyAccessToken"), expiry = Some(Instant.now), cmdPath = "gcp", cmdArgs = "").toString mustEqual
       "GcpAuth(accessToken=<redacted>)"
   }
 


### PR DESCRIPTION
gcp auth-provider's access-token and expity fields may be not set in
kubeconfig if kubectl has never been used to access the cluster. If this
is the case skuber fails with an exception while trying to read
kubeconfig because it expects those field to always be present

This commit makes access-token and expiry fields optional for the gcp
auth-provider

Fixes #301