### PR TITLE
Added support of projected volumes

### DIFF
--- a/client/src/main/scala/skuber/Volume.scala
+++ b/client/src/main/scala/skuber/Volume.scala
@@ -17,6 +17,17 @@ object Volume {
       directory: Option[String] = None)
     extends Source
 
+  sealed trait ProjectedSource
+  case class Projected( defaultMode:Option[Int] = None,
+                        sources: List[ProjectedSource]) extends Source
+  case class ProjectedSecret(name: String,
+                             items: Option[List[KeyToPath]] = None) extends ProjectedSource
+  case class ProjectedConfigMap(
+                                    name: String,
+                                    items: Option[List[KeyToPath]] = None,
+                                    mode: Option[Int] = None) extends ProjectedSource
+  case class ProjectedDownwardApi(items: List[DownwardApiVolumeFile] = List())  extends ProjectedSource
+
   case class Secret(
       secretName: String,
       items: Option[List[KeyToPath]] = None,

--- a/client/src/main/scala/skuber/Volume.scala
+++ b/client/src/main/scala/skuber/Volume.scala
@@ -17,15 +17,19 @@ object Volume {
       directory: Option[String] = None)
     extends Source
 
-  sealed trait ProjectedSource
-  case class Projected(defaultMode:Option[Int] = None,
-                       sources: List[ProjectedSource]) extends Source
-  case class ProjectedSecret(name: String,
-                             items: Option[List[KeyToPath]] = None) extends ProjectedSource
-  case class ProjectedConfigMap(name: String,
-                                items: Option[List[KeyToPath]] = None,
-                                mode: Option[Int] = None) extends ProjectedSource
-  case class ProjectedDownwardApi(items: List[DownwardApiVolumeFile] = List())  extends ProjectedSource
+  sealed trait VolumeProjection
+  case class ProjectedVolumeSource(defaultMode:Option[Int] = None,
+                                   sources: List[VolumeProjection]) extends Source
+  case class SecretProjection(name: String,
+                              items: Option[List[KeyToPath]] = None,
+                              optional: Option[Boolean] = None) extends VolumeProjection
+  case class ConfigMapProjection(name: String,
+                                 items: Option[List[KeyToPath]] = None,
+                                 optional: Option[Boolean] = None) extends VolumeProjection
+  case class DownwardAPIProjection(items: List[DownwardApiVolumeFile] = List())  extends VolumeProjection
+  case class ServiceAccountTokenProjection(audience: Option[String],
+                                          expirationSeconds: Option[Int],
+                                          path: String)
 
   case class Secret(
       secretName: String,

--- a/client/src/main/scala/skuber/Volume.scala
+++ b/client/src/main/scala/skuber/Volume.scala
@@ -18,14 +18,13 @@ object Volume {
     extends Source
 
   sealed trait ProjectedSource
-  case class Projected( defaultMode:Option[Int] = None,
-                        sources: List[ProjectedSource]) extends Source
+  case class Projected(defaultMode:Option[Int] = None,
+                       sources: List[ProjectedSource]) extends Source
   case class ProjectedSecret(name: String,
                              items: Option[List[KeyToPath]] = None) extends ProjectedSource
-  case class ProjectedConfigMap(
-                                    name: String,
-                                    items: Option[List[KeyToPath]] = None,
-                                    mode: Option[Int] = None) extends ProjectedSource
+  case class ProjectedConfigMap(name: String,
+                                items: Option[List[KeyToPath]] = None,
+                                mode: Option[Int] = None) extends ProjectedSource
   case class ProjectedDownwardApi(items: List[DownwardApiVolumeFile] = List())  extends ProjectedSource
 
   case class Secret(

--- a/client/src/main/scala/skuber/Volume.scala
+++ b/client/src/main/scala/skuber/Volume.scala
@@ -18,7 +18,7 @@ object Volume {
     extends Source
 
   sealed trait VolumeProjection
-  case class ProjectedVolumeSource(defaultMode:Option[Int] = None,
+  case class ProjectedVolumeSource(defaultMode: Option[Int] = None,
                                    sources: List[VolumeProjection]) extends Source
   case class SecretProjection(name: String,
                               items: Option[List[KeyToPath]] = None,
@@ -29,7 +29,7 @@ object Volume {
   case class DownwardAPIProjection(items: List[DownwardApiVolumeFile] = List())  extends VolumeProjection
   case class ServiceAccountTokenProjection(audience: Option[String],
                                           expirationSeconds: Option[Int],
-                                          path: String)
+                                          path: String) extends VolumeProjection
 
   case class Secret(
       secretName: String,

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -613,7 +613,7 @@ package object format {
           s.keys.headOption map {
             case "secret" => s.value("secret").as[Volume.ProjectedSecret]
             case "configMap" => s.value("configMap").as[Volume.ProjectedConfigMap]
-            case "downwardAPI" =>s.value("downwardAPI").as[Volume.ProjectedDownwardApi]
+            case "downwardAPI" => s.value("downwardAPI").as[Volume.ProjectedDownwardApi]
           }
         })))
   }

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -70,8 +70,7 @@ package object format {
     def reads(json: JsValue): JsResult[E#Value] = json match {
       case JsString(s) => {
         try {
-          JsSuccess(enum
-            .withName(s))
+          JsSuccess(enum.withName(s))
         } catch {
           case _: NoSuchElementException => JsError(s"Enumeration expected of type: '${enum.getClass}', but it does not appear to contain the value: '$s'")
         }
@@ -507,12 +506,10 @@ package object format {
     (JsPath \ "sizeLimit").formatNullable[Resource.Quantity]
   )(EmptyDir.apply _, unlift(EmptyDir.unapply))
 
-
   implicit val hostPathFormat: Format[HostPath] = Json.format[HostPath]
   implicit val keyToPathFormat: Format[KeyToPath] = Json.format[KeyToPath]
   implicit val volumeSecretFormat: Format[skuber.Volume.Secret] = Json.format[skuber.Volume.Secret]
   implicit val gitFormat: Format[GitRepo] = Json.format[GitRepo]
-
 
   implicit val objectFieldSelectorFormat: Format[ObjectFieldSelector] = (
     (JsPath \ "apiVersion").formatMaybeEmptyString() and
@@ -596,7 +593,6 @@ package object format {
      JsPath.read[JsValue].map[PersistentSource](j => GenericVolumeSource(j.toString))
    )
 
-
   implicit val projectedSecretFormat: Format[Volume.ProjectedSecret] = Json.format[ProjectedSecret]
   implicit val projectedConfigMapFormat: Format[Volume.ProjectedConfigMap] = Json.format[ProjectedConfigMap]
   implicit val projectedDownwardApiFormat: Format[Volume.ProjectedDownwardApi] = Json.format[ProjectedDownwardApi]
@@ -652,7 +648,6 @@ package object format {
      case da: DownwardApiVolumeSource => (JsPath \ "downwardAPI").write[DownwardApiVolumeSource](downwardApiVolumeSourceFormat).writes(da)
      case pvc: Volume.PersistentVolumeClaimRef => (JsPath \ "persistentVolumeClaim").write[Volume.PersistentVolumeClaimRef](persistentVolumeClaimRefFormat).writes(pvc)
    }
-
 
    implicit val volumeReads: Reads[Volume] = (
      (JsPath \ "name").read[String] and

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -594,14 +594,16 @@ package object format {
    )
 
 
-  implicit val projectedSecretFormat: Format[Volume.SecretProjection] = Json.format[SecretProjection]
-  implicit val projectedConfigMapFormat: Format[Volume.ConfigMapProjection] = Json.format[ConfigMapProjection]
-  implicit val projectedDownwardApiFormat: Format[Volume.DownwardAPIProjection] = Json.format[DownwardAPIProjection]
+  implicit val secretProjectionFormat: Format[Volume.SecretProjection] = Json.format[SecretProjection]
+  implicit val configMapProjectionFormat: Format[Volume.ConfigMapProjection] = Json.format[ConfigMapProjection]
+  implicit val downwardApiProjectionFormat: Format[Volume.DownwardAPIProjection] = Json.format[DownwardAPIProjection]
+  implicit val serviceAccountTokenProjectionFormat: Format[Volume.ServiceAccountTokenProjection] = Json.format[ServiceAccountTokenProjection]
 
   implicit val projectedVolumeSourceWrites: Writes[VolumeProjection] = Writes[VolumeProjection] {
-    case s: SecretProjection => (JsPath \ "secret").write[SecretProjection](projectedSecretFormat).writes(s)
-    case cm: ConfigMapProjection => (JsPath \ "configMap").write[ConfigMapProjection](projectedConfigMapFormat).writes(cm)
-    case dapi: DownwardAPIProjection => (JsPath \ "downwardAPI").write[DownwardAPIProjection](projectedDownwardApiFormat).writes(dapi)
+    case s: SecretProjection => (JsPath \ "secret").write[SecretProjection](secretProjectionFormat).writes(s)
+    case cm: ConfigMapProjection => (JsPath \ "configMap").write[ConfigMapProjection](configMapProjectionFormat).writes(cm)
+    case dapi: DownwardAPIProjection => (JsPath \ "downwardAPI").write[DownwardAPIProjection](downwardApiProjectionFormat).writes(dapi)
+    case sa: ServiceAccountTokenProjection => (JsPath \ "serviceAccountToken").write[ServiceAccountTokenProjection](serviceAccountTokenProjectionFormat).writes(sa)
   }
 
   implicit val projectedFormat: Format[ProjectedVolumeSource] = new Format[ProjectedVolumeSource] {
@@ -615,6 +617,7 @@ package object format {
             case "secret" => s.value("secret").as[Volume.SecretProjection]
             case "configMap" => s.value("configMap").as[Volume.ConfigMapProjection]
             case "downwardAPI" => s.value("downwardAPI").as[Volume.DownwardAPIProjection]
+            case "serviceAccountToken" => s.value("serviceAccountToken").as[Volume.ServiceAccountTokenProjection]
           }
         })))
   }

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -593,16 +593,6 @@ package object format {
      JsPath.read[JsValue].map[PersistentSource](j => GenericVolumeSource(j.toString))
    )
 
-   implicit val persVolumeSourceWrites: Writes[PersistentSource] = Writes[PersistentSource] {
-     case hp: HostPath => (JsPath \ "hostPath").write[HostPath](hostPathFormat).writes(hp)
-     case gced: GCEPersistentDisk => (JsPath \ "gcePersistentDisk").write[GCEPersistentDisk](gceFormat).writes(gced)
-     case awse: AWSElasticBlockStore => (JsPath \ "awsElasticBlockStore").write[AWSElasticBlockStore](awsFormat).writes(awse)
-     case nfs: NFS => (JsPath \ "nfs").write[NFS](nfsFormat).writes(nfs)
-     case gfs: Glusterfs => (JsPath \ "glusterfs").write[Glusterfs](glusterfsFormat).writes(gfs)
-     case rbd: RBD => (JsPath \ "rbd").write[RBD](rbdFormat).writes(rbd)
-     case iscsi: ISCSI => (JsPath \ "iscsi").write[ISCSI](iscsiFormat).writes(iscsi)
-     case GenericVolumeSource(json) => Json.parse(json)
-   }
 
   implicit val projectedSecretFormat: Format[Volume.ProjectedSecret] = Json.format[ProjectedSecret]
   implicit val projectedConfigMapFormat: Format[Volume.ProjectedConfigMap] = Json.format[ProjectedConfigMap]
@@ -629,25 +619,37 @@ package object format {
         })))
   }
 
-  implicit val volumeSourceReads: Reads[Source] = (
-    (JsPath \ "emptyDir").read[EmptyDir].map(x => x: Source) |
-      (JsPath \ "projected").read[Projected].map(x => x: Source) |
-      (JsPath \ "secret").read[skuber.Volume.Secret].map(x => x: Source) |
-      (JsPath \ "configMap").read[ConfigMapVolumeSource].map(x => x: Source) |
-      (JsPath \ "gitRepo").read[GitRepo].map(x => x: Source) |
-      (JsPath \ "persistentVolumeClaim").read[Volume.PersistentVolumeClaimRef].map(x => x: Source) |
-      (JsPath \ "downwardAPI").read[DownwardApiVolumeSource].map(x => x: Source) |
-      persVolumeSourceReads.map(x => x: Source)
-    )
+   implicit val volumeSourceReads: Reads[Source] = (
+     (JsPath \ "emptyDir").read[EmptyDir].map(x => x: Source) |
+     (JsPath \ "projected").read[Projected].map(x => x: Source) |
+     (JsPath \ "secret").read[skuber.Volume.Secret].map(x => x: Source) |
+     (JsPath \ "configMap").read[ConfigMapVolumeSource].map(x => x: Source) |
+     (JsPath \ "gitRepo").read[GitRepo].map(x => x: Source) |
+     (JsPath \ "persistentVolumeClaim").read[Volume.PersistentVolumeClaimRef].map(x => x: Source) |
+     (JsPath \ "downwardAPI").read[DownwardApiVolumeSource].map(x => x: Source) |
+     persVolumeSourceReads.map(x => x: Source)
+   )
+
+   implicit val persVolumeSourceWrites: Writes[PersistentSource] = Writes[PersistentSource] {
+     case hp: HostPath => (JsPath \ "hostPath").write[HostPath](hostPathFormat).writes(hp)
+     case gced: GCEPersistentDisk => (JsPath \ "gcePersistentDisk").write[GCEPersistentDisk](gceFormat).writes(gced)
+     case awse: AWSElasticBlockStore => (JsPath \ "awsElasticBlockStore").write[AWSElasticBlockStore](awsFormat).writes(awse)
+     case nfs: NFS => (JsPath \ "nfs").write[NFS](nfsFormat).writes(nfs)
+     case gfs: Glusterfs => (JsPath \ "glusterfs").write[Glusterfs](glusterfsFormat).writes(gfs)
+     case rbd: RBD => (JsPath \ "rbd").write[RBD](rbdFormat).writes(rbd)
+     case iscsi: ISCSI => (JsPath \ "iscsi").write[ISCSI](iscsiFormat).writes(iscsi)
+     case GenericVolumeSource(json) => Json.parse(json)
+   }
+
    implicit val volumeSourceWrites: Writes[Source] = Writes[Source] {
-     case ps: PersistentSource => persVolumeSourceWrites.writes(ps)
-     case ed: EmptyDir => (JsPath \ "emptyDir").write[EmptyDir](emptyDirFormat).writes(ed)
-     case p: Projected => (JsPath \ "projected").write[Projected](projectedFormat).writes(p)
-     case secr: skuber.Volume.Secret => (JsPath \ "secret").write[skuber.Volume.Secret](volumeSecretFormat).writes(secr)
-     case cfgMp: ConfigMapVolumeSource => (JsPath \ "configMap").write[ConfigMapVolumeSource](configMapVolFormat).writes(cfgMp)
-     case gitr: GitRepo => (JsPath \ "gitRepo").write[GitRepo](gitFormat).writes(gitr)
-     case da: DownwardApiVolumeSource => (JsPath \ "downwardAPI").write[DownwardApiVolumeSource](downwardApiVolumeSourceFormat).writes(da)
-     case pvc: Volume.PersistentVolumeClaimRef => (JsPath \ "persistentVolumeClaim").write[Volume.PersistentVolumeClaimRef](persistentVolumeClaimRefFormat).writes(pvc)
+       case ps: PersistentSource => persVolumeSourceWrites.writes(ps)
+       case ed: EmptyDir => (JsPath \ "emptyDir").write[EmptyDir](emptyDirFormat).writes(ed)
+       case p: Projected => (JsPath \ "projected").write[Projected](projectedFormat).writes(p)
+       case secr: skuber.Volume.Secret => (JsPath \ "secret").write[skuber.Volume.Secret](volumeSecretFormat).writes(secr)
+       case cfgMp: ConfigMapVolumeSource => (JsPath \ "configMap").write[ConfigMapVolumeSource](configMapVolFormat).writes(cfgMp)
+       case gitr: GitRepo => (JsPath \ "gitRepo").write[GitRepo](gitFormat).writes(gitr)
+       case da: DownwardApiVolumeSource => (JsPath \ "downwardAPI").write[DownwardApiVolumeSource](downwardApiVolumeSourceFormat).writes(da)
+       case pvc: Volume.PersistentVolumeClaimRef => (JsPath \ "persistentVolumeClaim").write[Volume.PersistentVolumeClaimRef](persistentVolumeClaimRefFormat).writes(pvc)
    }
 
    implicit val volumeReads: Reads[Volume] = (

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -593,6 +593,17 @@ package object format {
      JsPath.read[JsValue].map[PersistentSource](j => GenericVolumeSource(j.toString))
    )
 
+  implicit val persVolumeSourceWrites: Writes[PersistentSource] = Writes[PersistentSource] {
+    case hp: HostPath => (JsPath \ "hostPath").write[HostPath](hostPathFormat).writes(hp)
+    case gced: GCEPersistentDisk => (JsPath \ "gcePersistentDisk").write[GCEPersistentDisk](gceFormat).writes(gced)
+    case awse: AWSElasticBlockStore => (JsPath \ "awsElasticBlockStore").write[AWSElasticBlockStore](awsFormat).writes(awse)
+    case nfs: NFS => (JsPath \ "nfs").write[NFS](nfsFormat).writes(nfs)
+    case gfs: Glusterfs => (JsPath \ "glusterfs").write[Glusterfs](glusterfsFormat).writes(gfs)
+    case rbd: RBD => (JsPath \ "rbd").write[RBD](rbdFormat).writes(rbd)
+    case iscsi: ISCSI => (JsPath \ "iscsi").write[ISCSI](iscsiFormat).writes(iscsi)
+    case GenericVolumeSource(json) => Json.parse(json)
+  }
+
   implicit val projectedSecretFormat: Format[Volume.ProjectedSecret] = Json.format[ProjectedSecret]
   implicit val projectedConfigMapFormat: Format[Volume.ProjectedConfigMap] = Json.format[ProjectedConfigMap]
   implicit val projectedDownwardApiFormat: Format[Volume.ProjectedDownwardApi] = Json.format[ProjectedDownwardApi]
@@ -617,16 +628,6 @@ package object format {
           }
         })))
   }
-   implicit val persVolumeSourceWrites: Writes[PersistentSource] = Writes[PersistentSource] {
-     case hp: HostPath => (JsPath \ "hostPath").write[HostPath](hostPathFormat).writes(hp)
-     case gced: GCEPersistentDisk => (JsPath \ "gcePersistentDisk").write[GCEPersistentDisk](gceFormat).writes(gced)
-     case awse: AWSElasticBlockStore => (JsPath \ "awsElasticBlockStore").write[AWSElasticBlockStore](awsFormat).writes(awse)
-     case nfs: NFS => (JsPath \ "nfs").write[NFS](nfsFormat).writes(nfs)
-     case gfs: Glusterfs => (JsPath \ "glusterfs").write[Glusterfs](glusterfsFormat).writes(gfs)
-     case rbd: RBD => (JsPath \ "rbd").write[RBD](rbdFormat).writes(rbd)
-     case iscsi: ISCSI => (JsPath \ "iscsi").write[ISCSI](iscsiFormat).writes(iscsi)
-     case GenericVolumeSource(json) => Json.parse(json)
-   }
 
   implicit val volumeSourceReads: Reads[Source] = (
     (JsPath \ "emptyDir").read[EmptyDir].map(x => x: Source) |

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -614,11 +614,10 @@ package object format {
       JsSuccess(Projected(
         (json \ "defaultMode").asOpt[Int],
         (json \ "sources").as[List[JsObject]].flatMap(s => {
-          s.keys.headOption match {
-            case Some("secret") => Some(s.value("secret").as[Volume.ProjectedSecret])
-            case Some("configMap") => Some(s.value("configMap").as[Volume.ProjectedConfigMap])
-            case Some("downwardAPI") => Some(s.value("downwardAPI").as[Volume.ProjectedDownwardApi])
-            case _ => None
+          s.keys.headOption map {
+            case "secret" => s.value("secret").as[Volume.ProjectedSecret]
+            case "configMap" => s.value("configMap").as[Volume.ProjectedConfigMap]
+            case "downwardAPI" =>s.value("downwardAPI").as[Volume.ProjectedDownwardApi]
           }
         })))
   }

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -593,16 +593,16 @@ package object format {
      JsPath.read[JsValue].map[PersistentSource](j => GenericVolumeSource(j.toString))
    )
 
-  implicit val persVolumeSourceWrites: Writes[PersistentSource] = Writes[PersistentSource] {
-    case hp: HostPath => (JsPath \ "hostPath").write[HostPath](hostPathFormat).writes(hp)
-    case gced: GCEPersistentDisk => (JsPath \ "gcePersistentDisk").write[GCEPersistentDisk](gceFormat).writes(gced)
-    case awse: AWSElasticBlockStore => (JsPath \ "awsElasticBlockStore").write[AWSElasticBlockStore](awsFormat).writes(awse)
-    case nfs: NFS => (JsPath \ "nfs").write[NFS](nfsFormat).writes(nfs)
-    case gfs: Glusterfs => (JsPath \ "glusterfs").write[Glusterfs](glusterfsFormat).writes(gfs)
-    case rbd: RBD => (JsPath \ "rbd").write[RBD](rbdFormat).writes(rbd)
-    case iscsi: ISCSI => (JsPath \ "iscsi").write[ISCSI](iscsiFormat).writes(iscsi)
-    case GenericVolumeSource(json) => Json.parse(json)
-  }
+   implicit val persVolumeSourceWrites: Writes[PersistentSource] = Writes[PersistentSource] {
+     case hp: HostPath => (JsPath \ "hostPath").write[HostPath](hostPathFormat).writes(hp)
+     case gced: GCEPersistentDisk => (JsPath \ "gcePersistentDisk").write[GCEPersistentDisk](gceFormat).writes(gced)
+     case awse: AWSElasticBlockStore => (JsPath \ "awsElasticBlockStore").write[AWSElasticBlockStore](awsFormat).writes(awse)
+     case nfs: NFS => (JsPath \ "nfs").write[NFS](nfsFormat).writes(nfs)
+     case gfs: Glusterfs => (JsPath \ "glusterfs").write[Glusterfs](glusterfsFormat).writes(gfs)
+     case rbd: RBD => (JsPath \ "rbd").write[RBD](rbdFormat).writes(rbd)
+     case iscsi: ISCSI => (JsPath \ "iscsi").write[ISCSI](iscsiFormat).writes(iscsi)
+     case GenericVolumeSource(json) => Json.parse(json)
+   }
 
   implicit val projectedSecretFormat: Format[Volume.ProjectedSecret] = Json.format[ProjectedSecret]
   implicit val projectedConfigMapFormat: Format[Volume.ProjectedConfigMap] = Json.format[ProjectedConfigMap]

--- a/client/src/test/resources/examplePodExtendedSpec.json
+++ b/client/src/test/resources/examplePodExtendedSpec.json
@@ -75,6 +75,10 @@
           {
             "name": "logs",
             "mountPath": "/var/log/app.log"
+          },
+          {
+            "mountPath": "/config",
+            "name": "config-volume"
           }
         ],
         "terminationMessagePolicy": "FallbackToLogsOnError",
@@ -124,6 +128,24 @@
       }
     ],
     "volumes": [
+      {
+        "name": "config-volume",
+        "projected": {
+          "defaultMode": 128,
+          "sources": [
+            {
+              "secret": {
+                "name": "verysecret"
+              }
+            },
+            {
+              "configMap": {
+                "name": "justConfig"
+              }
+            }
+          ]
+        }
+      },
       {
         "name": "keys",
         "secret": {

--- a/client/src/test/resources/examplePodExtendedSpec.json
+++ b/client/src/test/resources/examplePodExtendedSpec.json
@@ -135,12 +135,41 @@
           "sources": [
             {
               "secret": {
-                "name": "verysecret"
+                "name": "verysecret",
+                "optional": false,
+                "items": [
+                  {
+                    "key": "host-key-pub",
+                    "path": "host_key.pub"
+                  },
+                  {
+                    "key": "other-key",
+                    "path": "worker_key"
+                  }
+                ]
               }
             },
             {
               "configMap": {
-                "name": "justConfig"
+                "name": "justConfig",
+                "optional": false,
+                "items": [
+                  {
+                    "key": "host-key-pub",
+                    "path": "host_key.pub"
+                  },
+                  {
+                    "key": "other-key",
+                    "path": "worker_key"
+                  }
+                ]
+              }
+            },
+            {
+              "serviceAccountToken" : {
+                "path": "vault-token",
+                "expirationSeconds": 7200,
+                "audience": "vault"
               }
             }
           ]

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -1,21 +1,16 @@
 package skuber.json
 
-import org.specs2.mutable.Specification
-import org.specs2.execute.Result
-import org.specs2.execute.Failure
-import org.specs2.execute.Success
-
-import scala.math.BigInt
-import scala.io.Source
-import java.util.Calendar
 import java.net.URL
 
-import skuber._
-import format._
+import org.specs2.execute.{Failure, Result}
+import org.specs2.mutable.Specification
 import play.api.libs.json._
+import skuber.Volume.{ConfigMapProjection, KeyToPath, SecretProjection, ServiceAccountTokenProjection}
+import skuber._
 import skuber.apps.StatefulSet
-import skuber.Pod.ExistsToleration
-import skuber.Volume.{ConfigMapProjection, SecretProjection}
+import skuber.json.format._
+
+import scala.io.Source
 
 /**
  * @author David O'Riordan
@@ -394,10 +389,8 @@ import Pod._
     }
 
     "a pod with nodeAffinity can be read and written as json" >> {
-      import Affinity.NodeAffinity
-      import Affinity.NodeSelectorOperator
-      import NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-      import NodeAffinity.{PreferredSchedulingTerm, PreferredSchedulingTerms}
+      import Affinity.{NodeAffinity, NodeSelectorOperator}
+      import NodeAffinity.{PreferredSchedulingTerm, PreferredSchedulingTerms, RequiredDuringSchedulingIgnoredDuringExecution}
 
       val podJsonSource = Source.fromURL(getClass.getResource("/examplePodWithNodeAffinity.json"))
       val podJsonStr = podJsonSource.mkString
@@ -430,10 +423,7 @@ import Pod._
     }
 
     "NodeSelectorTerm be properly read and written as json" >> {
-      import Affinity.NodeSelectorTerm
-      import Affinity.NodeSelectorOperator
-      import Affinity.NodeSelectorRequirement
-      import Affinity.NodeSelectorRequirements
+      import Affinity.{NodeSelectorOperator, NodeSelectorRequirement, NodeSelectorRequirements, NodeSelectorTerm}
 
       val nodeSelectorTermJsonSource = Source.fromURL(getClass.getResource("/exampleNodeSelectorTerm.json"))
       val nodeSelectorTermJson = nodeSelectorTermJsonSource.mkString
@@ -451,10 +441,7 @@ import Pod._
     }
 
     "NodeSelectorTerm with no matchExpressions be properly read and written as json" >> {
-      import Affinity.NodeSelectorTerm
-      import Affinity.NodeSelectorOperator
-      import Affinity.NodeSelectorRequirement
-      import Affinity.NodeSelectorRequirements
+      import Affinity.{NodeSelectorOperator, NodeSelectorRequirement, NodeSelectorRequirements, NodeSelectorTerm}
 
       val nodeSelectorTermJsonSource = Source.fromURL(getClass.getResource("/exampleNodeSelectorTermNoMatchExpressions.json"))
       val nodeSelectorTermJson = nodeSelectorTermJsonSource.mkString
@@ -469,10 +456,7 @@ import Pod._
     }
 
     "NodeSelectorTerm with no matchFields be properly read and written as json" >> {
-      import Affinity.NodeSelectorTerm
-      import Affinity.NodeSelectorOperator
-      import Affinity.NodeSelectorRequirement
-      import Affinity.NodeSelectorRequirements
+      import Affinity.{NodeSelectorOperator, NodeSelectorRequirement, NodeSelectorRequirements, NodeSelectorTerm}
 
       val nodeSelectorTermJsonSource = Source.fromURL(getClass.getResource("/exampleNodeSelectorTermNoMatchFields.json"))
       val nodeSelectorTermJson = nodeSelectorTermJsonSource.mkString
@@ -498,10 +482,8 @@ import Pod._
     }
 
     "NodeAffinity be properly read and written as json" >> {
-      import Affinity.NodeAffinity
-      import Affinity.NodeSelectorOperator
-      import NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-      import NodeAffinity.{PreferredSchedulingTerm, PreferredSchedulingTerms}
+      import Affinity.{NodeAffinity, NodeSelectorOperator}
+      import NodeAffinity.{PreferredSchedulingTerm, PreferredSchedulingTerms, RequiredDuringSchedulingIgnoredDuringExecution}
 
       val affinityJsonSource = Source.fromURL(getClass.getResource("/exampleAffinity.json"))
       val affinityJsonStr = affinityJsonSource.mkString
@@ -522,10 +504,8 @@ import Pod._
     }
 
     "NodeAffinity without preferences be properly read and written as json" >> {
-      import Affinity.NodeAffinity
-      import Affinity.NodeSelectorOperator
-      import NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-      import NodeAffinity.{PreferredSchedulingTerm, PreferredSchedulingTerms}
+      import Affinity.{NodeAffinity, NodeSelectorOperator}
+      import NodeAffinity.{PreferredSchedulingTerms, RequiredDuringSchedulingIgnoredDuringExecution}
 
       val affinityJsonSource = Source.fromURL(getClass.getResource("/exampleAffinityNoPreferences.json"))
       val affinityJsonStr = affinityJsonSource.mkString
@@ -544,9 +524,7 @@ import Pod._
     }
 
     "NodeAffinity without requirements be properly read and written as json" >> {
-      import Affinity.NodeAffinity
-      import Affinity.NodeSelectorOperator
-      import NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+      import Affinity.{NodeAffinity, NodeSelectorOperator}
       import NodeAffinity.{PreferredSchedulingTerm, PreferredSchedulingTerms}
 
       val affinityJsonSource = Source.fromURL(getClass.getResource("/exampleAffinityNoRequirements.json"))
@@ -566,9 +544,7 @@ import Pod._
     }
 
     "PodAffinity can be properly read and written as json" >> {
-      import Affinity.NodeAffinity
-      import Affinity.NodeSelectorOperator
-      import Affinity.{PodAffinity, PodAffinityTerm, WeightedPodAffinityTerm}
+      import Affinity.{NodeAffinity, NodeSelectorOperator}
 
       val affinityJsonSource = Source.fromURL(getClass.getResource("/exampleAffinityNoRequirements.json"))
       val affinityJsonStr = affinityJsonSource.mkString
@@ -662,11 +638,16 @@ import Pod._
     val readPod = Json.fromJson[Pod](json).get
     readPod mustEqual pod
 
-    val configVolume = pod.spec.get.volumes.filter(_.name == "config-volume").head
+    val configVolume = pod.spec.get.volumes.find(_.name == "config-volume").get
     configVolume.source must beAnInstanceOf[Volume.ProjectedVolumeSource]
     configVolume.source.asInstanceOf[Volume.ProjectedVolumeSource].defaultMode mustEqual Some(128)
+    configVolume.source.asInstanceOf[Volume.ProjectedVolumeSource].sources mustEqual
+      List(SecretProjection("verysecret",Some(List(KeyToPath("host-key-pub", "host_key.pub"), KeyToPath("other-key","worker_key"))),Some(false)),
+      ConfigMapProjection("justConfig",Some(List(KeyToPath("host-key-pub", "host_key.pub"), KeyToPath("other-key", "worker_key"))),Some(false)),
+      ServiceAccountTokenProjection(Some("vault"),Some(7200),"vault-token")
+    )
 
-    configVolume.source.asInstanceOf[Volume.ProjectedVolumeSource].sources mustEqual List(SecretProjection("verysecret",None), ConfigMapProjection("justConfig",None,None))
+
   }
 
 }

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -15,7 +15,7 @@ import format._
 import play.api.libs.json._
 import skuber.apps.StatefulSet
 import skuber.Pod.ExistsToleration
-import skuber.Volume.{ProjectedConfigMap, ProjectedSecret}
+import skuber.Volume.{ConfigMapProjection, SecretProjection}
 
 /**
  * @author David O'Riordan
@@ -663,10 +663,10 @@ import Pod._
     readPod mustEqual pod
 
     val configVolume = pod.spec.get.volumes.filter(_.name == "config-volume").head
-    configVolume.source must beAnInstanceOf[Volume.Projected]
-    configVolume.source.asInstanceOf[Volume.Projected].defaultMode mustEqual Some(128)
+    configVolume.source must beAnInstanceOf[Volume.ProjectedVolumeSource]
+    configVolume.source.asInstanceOf[Volume.ProjectedVolumeSource].defaultMode mustEqual Some(128)
 
-    configVolume.source.asInstanceOf[Volume.Projected].sources mustEqual List(ProjectedSecret("verysecret",None), ProjectedConfigMap("justConfig",None,None))
+    configVolume.source.asInstanceOf[Volume.ProjectedVolumeSource].sources mustEqual List(SecretProjection("verysecret",None), ConfigMapProjection("justConfig",None,None))
   }
 
 }

--- a/client/src/test/scala/skuber/json/PodFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/PodFormatSpec.scala
@@ -15,6 +15,7 @@ import format._
 import play.api.libs.json._
 import skuber.apps.StatefulSet
 import skuber.Pod.ExistsToleration
+import skuber.Volume.{ProjectedConfigMap, ProjectedSecret}
 
 /**
  * @author David O'Riordan
@@ -660,6 +661,12 @@ import Pod._
     val json = Json.toJson(pod)
     val readPod = Json.fromJson[Pod](json).get
     readPod mustEqual pod
+
+    val configVolume = pod.spec.get.volumes.filter(_.name == "config-volume").head
+    configVolume.source must beAnInstanceOf[Volume.Projected]
+    configVolume.source.asInstanceOf[Volume.Projected].defaultMode mustEqual Some(128)
+
+    configVolume.source.asInstanceOf[Volume.Projected].sources mustEqual List(ProjectedSecret("verysecret",None), ProjectedConfigMap("justConfig",None,None))
   }
 
 }


### PR DESCRIPTION
Projected volumes are very useful, allowing combining of several configmaps/secrets into one and reducing clutter in deployments and applications configs. 

I was somewhat surprised not finding support for projected volumes in skuber.

This PR adds the missing pieces.