### PR TITLE
JFrog Xray Security Issues : FastXML (Jackson) & Bouncy Castle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersi
 val snakeYaml =  "org.yaml" % "snakeyaml" % "1.25"
 val commonsIO = "commons-io" % "commons-io" % "2.6"
 val commonsCodec = "commons-codec" % "commons-codec" % "1.14"
-val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % "1.64"
+val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % "1.66"
 
 // the client API request/response handing uses Akka Http
 val akkaHttp = "com.typesafe.akka" %% "akka-http" % "10.1.11"
@@ -24,7 +24,7 @@ val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
 val logback = "ch.qos.logback" % "logback-classic" % "1.1.3" % Runtime
 
 // the Json formatters are based on Play Json
-val playJson = "com.typesafe.play" %% "play-json" % "2.7.4"
+val playJson = "com.typesafe.play" %% "play-json" % "2.9.0"
 
 // Need Java 8 or later as the java.time package is used to represent K8S timestamps
 scalacOptions += "-target:jvm-1.8"

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -402,7 +402,7 @@ package object format {
     (JsPath \ "requests").formatMaybeEmptyMap[Resource.Quantity]
   )(Resource.Requirements.apply _, unlift(Resource.Requirements.unapply))
 
-  implicit val protocolFmt = Format(enumReads(Protocol, Protocol.TCP), enumWrites)
+  implicit val protocolFmt: Format[skuber.Protocol.Value] = Format(enumReads(Protocol, Protocol.TCP), enumWrites)
 
   implicit val formatCntrProt: Format[Container.Port] = (
     (JsPath \ "containerPort").format[Int] and

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.13


### PR DESCRIPTION
This PR addresses the following security vulnerabilities:
* Infected Component - Com.fasterxml.jackson.core:jackson-databind
Cves
(CVSS V2: 7.6/CVSS:2.0/AV:N/AC:H/Au:N/C:C/I:C/A:C)
References
http://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-10650
https://github.com/FasterXML/jackson-databind/commit/a424c038ba0c0d65e579e22001dec925902ac0ef
https://sid.softek.jp/content/show/35081
https://github.com/FasterXML/jackson-databind/issues/2658

* Infected Component - Org.bouncycastle:bcprov-jdk15on
Cves
CVE-2018-5382 (CVSS V2: 7.5/CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P)
References
http://www.securityfocus.com/bid/103453
https://www.bouncycastle.org/releasenotes.html
https://www.kb.cert.org/vuls/id/306792