### PR TITLE
Use lower-level connection-based Akka HTTP API

### DIFF
--- a/client/src/main/scala/skuber/api/client/exec/PodExecImpl.scala
+++ b/client/src/main/scala/skuber/api/client/exec/PodExecImpl.scala
@@ -49,9 +49,9 @@ object PodExecImpl {
     queries ++= command.map("command" -> _)
 
     // Determine scheme and connection context based on SSL context
-    val (scheme, connectionContext) = requestContext.sslContext match {
-      case Some(ssl) =>
-        ("wss",ConnectionContext.https(ssl, enabledProtocols = Some(scala.collection.immutable.Seq("TLSv1.2", "TLSv1"))))
+    val (scheme, connectionContext) = requestContext.httpsConnectionContext match {
+      case Some(connectionContext) =>
+        ("wss",connectionContext)
       case None =>
         ("ws", Http().defaultClientHttpsContext)
     }

--- a/client/src/main/scala/skuber/api/watch/LongPollingPool.scala
+++ b/client/src/main/scala/skuber/api/watch/LongPollingPool.scala
@@ -4,8 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
 import akka.http.scaladsl.{Http, HttpsConnectionContext}
-import akka.stream.Materializer
-import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.{Flow, Sink, Source}
 import skuber.api.client.Pool
 
 import scala.concurrent.duration._
@@ -18,29 +17,26 @@ private[api] object LongPollingPool {
                clientConnectionSettings: ClientConnectionSettings)(implicit system: ActorSystem): Pool[T] = {
     implicit val ec = system.dispatcher
     schema match {
-      case "http" | "https" =>
+      case "http" =>
         Flow[(HttpRequest, T)]
           .mapAsync(1) {
             case (request, userdata) =>
-              Http()
-                .singleRequest(
-                  request,
-                  httpsConnectionContext.getOrElse(Http().defaultClientHttpsContext),
-                  buildHostConnectionPool(poolIdleTimeout, clientConnectionSettings, system)
-                )
+              Source.single(request)
+                .via(Http().outgoingConnection(host, port, settings = clientConnectionSettings))
                 .map(response => (Success(response), userdata))
+                .runWith(Sink.head)
+          }
+      case "https" =>
+        Flow[(HttpRequest, T)]
+          .mapAsync(1) {
+            case (request, userdata) =>
+              Source.single(request)
+                .via(Http().outgoingConnectionHttps(host, port, httpsConnectionContext.get, settings = clientConnectionSettings))
+                .map(response => (Success(response), userdata))
+                .runWith(Sink.head)
           }
       case unsupported =>
         throw new IllegalArgumentException(s"Schema $unsupported is not supported")
     }
-  }
-
-  private def buildHostConnectionPool[T](poolIdleTimeout: Duration, clientConnectionSettings: ClientConnectionSettings, system: ActorSystem) = {
-    ConnectionPoolSettings(system)
-      .withMaxConnections(1)              // Limit number the of open connections to one
-      .withPipeliningLimit(1)             // Limit pipelining of requests to one
-      .withMaxRetries(0)                  // Disables retries
-      .withIdleTimeout(poolIdleTimeout)   // Automatically shutdown connection pool after timeout
-      .withConnectionSettings(clientConnectionSettings)
   }
 }


### PR DESCRIPTION
LongPollingPool was calling newHostConnectionPool for each materialization of
the 'watch'. While that is not wrong per se (pools are cleaned up when they
have been idle for some time), it can lead to a large number of pools in memory
when the Watch streams are regularly restarted.

~By using the request-based API here, Akka HTTP will share connection pools
among requests with the same ConnectionContext, which should lead to less
resource usage in such scenario's.~

By using the lower-level connection-based API here, skuber will no longer need
to rely on 'scaled-down' connection pools but can use individual connectionions
directly.