### PR TITLE
Improve handling of ERROR Watch events

### DIFF
--- a/client/src/main/scala/skuber/api/client/KubernetesClient.scala
+++ b/client/src/main/scala/skuber/api/client/KubernetesClient.scala
@@ -232,10 +232,11 @@ trait KubernetesClient {
     * applicable type (e.g. PodList, DeploymentList) and then supplies that to this method to receive any future updates. If no resource version is specified,
     * a single ADDED event will be produced for an already existing object followed by events for any future changes.
     * @param bufSize optional buffer size for received object updates, normally the default is more than enough
+    * @param errorHandler an optional function that takes a single string parameter - it will be invoked with the error details whenever ERROR events are received
     * @tparam O the type of the resource
     * @return A future containing an Akka streams Source of WatchEvents that will be emitted
     */
-  def watchContinuously[O <: ObjectResource](name: String, sinceResourceVersion: Option[String] = None, bufSize: Int = 10000)(
+  def watchContinuously[O <: ObjectResource](name: String, sinceResourceVersion: Option[String] = None, bufSize: Int = 10000, errorHandler: Option[String => _] = None)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Source[WatchEvent[O], _]
 
   /**
@@ -248,10 +249,11 @@ trait KubernetesClient {
     * applicable type (e.g. PodList, DeploymentList) and then supplies that to this method to receive any future updates. If no resource version is specified,
     * a single ADDED event will be produced for an already existing object followed by events for any future changes.
     * @param bufSize optional buffer size for received object updates, normally the default is more than enough
+    * @param errorHandler an optional function that takes a single string parameter - it will be invoked with the error details whenever ERROR events are received
     * @tparam O the type pf the resource
     * @return A future containing an Akka streams Source of WatchEvents that will be emitted
     */
-  def watchAllContinuously[O <: ObjectResource](sinceResourceVersion: Option[String] = None, bufSize: Int = 10000)(
+  def watchAllContinuously[O <: ObjectResource](sinceResourceVersion: Option[String] = None, bufSize: Int = 10000, errorHandler: Option[String => _] = None)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Source[WatchEvent[O], _]
 
 /**
@@ -261,10 +263,11 @@ trait KubernetesClient {
   * for the meaning of the options. Note that the `watch` flag in the options will be ignored / overridden by the client, which
   * ensures a watch is always requested on the server.
   * @param bufsize optional buffer size for received object updates, normally the default is more than enough
+  * @param errorHandler an optional function that takes a single string parameter - it will be invoked with the error details whenever ERROR events are received
   * @tparam O the resource type to watch
   * @return A future containing an Akka streams Source of WatchEvents that will be emitted
   */
-  def watchWithOptions[O <: ObjectResource](options: ListOptions, bufsize: Int = 10000)(
+  def watchWithOptions[O <: ObjectResource](options: ListOptions, bufsize: Int = 10000, errorHandler: Option[String => _] = None)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Source[WatchEvent[O], _]
 
   /**

--- a/client/src/main/scala/skuber/api/client/impl/KubernetesClientImpl.scala
+++ b/client/src/main/scala/skuber/api/client/impl/KubernetesClientImpl.scala
@@ -470,14 +470,14 @@ class KubernetesClientImpl private[client] (
   override def watch[O <: ObjectResource](name: String, sinceResourceVersion: Option[String] = None, bufSize: Int = 10000)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Future[Source[WatchEvent[O], _]] =
   {
-    Watch.events(this, name, sinceResourceVersion, bufSize)
+    Watch.events(this, name, sinceResourceVersion, bufSize, None)
   }
 
   // watch events on all objects of specified kind in current namespace
   override def watchAll[O <: ObjectResource](sinceResourceVersion: Option[String] = None, bufSize: Int = 10000)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Future[Source[WatchEvent[O], _]] =
   {
-    Watch.eventsOnKind[O](this, sinceResourceVersion, bufSize)
+    Watch.eventsOnKind[O](this, sinceResourceVersion, bufSize, None)
   }
 
   override def watchContinuously[O <: ObjectResource](obj: O)(
@@ -486,24 +486,24 @@ class KubernetesClientImpl private[client] (
     watchContinuously(obj.name)
   }
 
-  override def watchContinuously[O <: ObjectResource](name: String, sinceResourceVersion: Option[String] = None, bufSize: Int = 10000)(
+  override def watchContinuously[O <: ObjectResource](name: String, sinceResourceVersion: Option[String] = None, bufSize: Int = 10000, errorHandler: Option[String => _] = None)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Source[WatchEvent[O], _] =
   {
     val options=ListOptions(resourceVersion = sinceResourceVersion, timeoutSeconds = Some(watchContinuouslyRequestTimeout.toSeconds) )
-    WatchSource(this, buildLongPollingPool(), Some(name), options, bufSize)
+    WatchSource(this, buildLongPollingPool(), Some(name), options, bufSize, errorHandler)
   }
 
-  override def watchAllContinuously[O <: ObjectResource](sinceResourceVersion: Option[String] = None, bufSize: Int = 10000)(
+  override def watchAllContinuously[O <: ObjectResource](sinceResourceVersion: Option[String] = None, bufSize: Int = 10000, errorHandler: Option[String => _] = None)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Source[WatchEvent[O], _] =
   {
     val options=ListOptions(resourceVersion = sinceResourceVersion, timeoutSeconds = Some(watchContinuouslyRequestTimeout.toSeconds))
-    WatchSource(this, buildLongPollingPool(), None, options, bufSize)
+    WatchSource(this, buildLongPollingPool(), None, options, bufSize, errorHandler)
   }
 
-  override def watchWithOptions[O <: skuber.ObjectResource](options: ListOptions, bufsize: Int = 10000)(
+  override def watchWithOptions[O <: skuber.ObjectResource](options: ListOptions, bufsize: Int = 10000, errorHandler: Option[String => _] = None)(
     implicit fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Source[WatchEvent[O], _] =
   {
-    WatchSource(this, buildLongPollingPool(), None, options, bufsize)
+    WatchSource(this, buildLongPollingPool(), None, options, bufsize, errorHandler)
   }
 
   private def buildLongPollingPool[O <: ObjectResource]() = {

--- a/client/src/main/scala/skuber/api/watch/BytesToWatchEventSource.scala
+++ b/client/src/main/scala/skuber/api/watch/BytesToWatchEventSource.scala
@@ -1,10 +1,12 @@
 package skuber.api.watch
 
-import akka.stream.scaladsl.{JsonFraming, Source}
+import akka.NotUsed
+import akka.stream.scaladsl.{JsonFraming, Sink, Source}
 import akka.util.ByteString
-import play.api.libs.json.{Format, JsError, JsSuccess, Json}
+import play.api.libs.json.{Format, JsError, JsObject, JsString, JsSuccess, JsValue, Json}
 import skuber.ObjectResource
-import skuber.api.client.{K8SException, Status, WatchEvent}
+import skuber.api.client.impl.KubernetesClientImpl
+import skuber.api.client.{K8SException, LoggingContext, Status, WatchEvent}
 
 import scala.concurrent.ExecutionContext
 
@@ -12,12 +14,29 @@ import scala.concurrent.ExecutionContext
   * Convert a source of bytes to a source of watch events of type O
   */
 private[api] object BytesToWatchEventSource {
-  def apply[O <: ObjectResource](bytesSource: Source[ByteString, _], bufSize: Int)(implicit ec: ExecutionContext, format: Format[O]): Source[WatchEvent[O], _] = {
+  def apply[O <: ObjectResource](client: KubernetesClientImpl, bytesSource: Source[ByteString, _], bufSize: Int, errorHandlerOpt: Option[String => _] = None)(implicit ec: ExecutionContext, format: Format[O], lc: LoggingContext): Source[WatchEvent[O], _] = {
     import skuber.json.format.apiobj.watchEventFormat
     bytesSource.via(
       JsonFraming.objectScanner(bufSize)
     ).map { singleEventBytes =>
-      Json.parse(singleEventBytes.utf8String).validate(watchEventFormat[O]) match {
+      Json.parse(singleEventBytes.utf8String).as[JsObject]
+    }.filter {
+      case JsObject(underlying) if underlying.get("type").contains(JsString("ERROR")) =>
+        // handle error events, removing them from downstream emitted elements
+        val handled = for {
+          errorHandler <- errorHandlerOpt
+          errorObj <- underlying.get("object").flatMap(_.asOpt[JsObject])
+        } yield {
+          errorHandler(errorObj.toString)
+        }
+        if (!handled.isDefined) {
+          // no error handler, just log instead
+          client.logWarn(s"Watcher received ERROR event: $underlying")
+        }
+        false
+      case _ => true
+    }.map { eventJson =>
+      eventJson.validate(watchEventFormat[O]) match {
         case JsSuccess(value, _) => value
         case JsError(e) => throw new K8SException(Status(message = Some("Error parsing watched object"), details = Some(e.toString)))
       }

--- a/client/src/test/scala/skuber/api/BytesToWatchEventSourceSpec.scala
+++ b/client/src/test/scala/skuber/api/BytesToWatchEventSourceSpec.scala
@@ -7,8 +7,11 @@ import org.specs2.mutable.Specification
 import akka.util.ByteString
 import akka.stream.scaladsl.{Sink, Source}
 import akka.actor.ActorSystem
+import org.scalatestplus.mockito.MockitoSugar.mock
+import skuber.api.client.impl.KubernetesClientImpl
 import skuber.api.watch.BytesToWatchEventSource
 
+import scala.collection.mutable
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 
@@ -21,11 +24,12 @@ class BytesToWatchEventSourceSpec extends Specification {
   implicit val system: ActorSystem = ActorSystem("test")
   implicit val ec: ExecutionContext = system.dispatcher
   implicit val loggingContext: LoggingContext = new LoggingContext { override def output:String="test" }
+  val client = mock[KubernetesClientImpl]
 
   "A single chunk containing a single Watch event can be read correctly" >> {
     val eventsAsStr =  """{"type":"MODIFIED","object":{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"frontend","namespace":"default","selfLink":"/api/v1/namespaces/default/replicationcontrollers/frontend","uid":"246f12b6-719b-11e5-89ae-0800279dd272","resourceVersion":"12803","generation":2,"creationTimestamp":"2015-10-13T11:11:24Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":3,"observedGeneration":2}}}"""
     val bytesSource = Source.single(ByteString(eventsAsStr))
-    val watchEventSource = BytesToWatchEventSource[ReplicationController](bytesSource, 1000)
+    val watchEventSource = BytesToWatchEventSource[ReplicationController](client, bytesSource, 1000, None)
 
     val eventSink = Sink.head[WatchEvent[ReplicationController]]
     val run: Future[WatchEvent[ReplicationController]] = watchEventSource.runWith(eventSink)
@@ -39,7 +43,7 @@ class BytesToWatchEventSourceSpec extends Specification {
 {"type":"MODIFIED","object":{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"frontend","namespace":"default","selfLink":"/api/v1/namespaces/default/replicationcontrollers/frontend","uid":"246f12b6-719b-11e5-89ae-0800279dd272","resourceVersion":"12804","generation":2,"creationTimestamp":"2015-10-13T11:11:24Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":0,"observedGeneration":2}}}
 """
     val bytesSource = Source.single(ByteString(eventsAsStr))
-    val watchEventSource: Source[WatchEvent[ReplicationController], _] = BytesToWatchEventSource[ReplicationController](bytesSource, 1000)
+    val watchEventSource: Source[WatchEvent[ReplicationController], _] = BytesToWatchEventSource[ReplicationController](client, bytesSource, 1000, None)
 
     val eventSink = Sink.seq[WatchEvent[ReplicationController]]
     val run: Future[Seq[WatchEvent[ReplicationController]]] = watchEventSource.runWith(eventSink)
@@ -57,7 +61,7 @@ class BytesToWatchEventSourceSpec extends Specification {
       val event2AsStr = """4Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":0,"observedGeneration":2}}}
 """
       val bytesSource = Source(List(ByteString(event1AsStr), ByteString(event2AsStr)))
-      val watchEventSource = BytesToWatchEventSource[ReplicationController](bytesSource, 1000)
+      val watchEventSource = BytesToWatchEventSource[ReplicationController](client, bytesSource, 1000, None)
 
       val eventSink = Sink.seq[WatchEvent[ReplicationController]]
       val run: Future[Seq[WatchEvent[ReplicationController]]] = watchEventSource.runWith(eventSink)
@@ -78,7 +82,7 @@ class BytesToWatchEventSourceSpec extends Specification {
 {"type":"MODIFIED","object":{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"frontend","namespace":"default","selfLink":"/api/v1/namespaces/default/replicationcontrollers/frontend","uid":"246f12b6-719b-11e5-89ae-0800279dd272","resourceVersion":"12803","generation":2,"creationTimestamp":"2015-10-13T11:11:24Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":0,"observedGeneration":2}}}
 """
       val bytesSource = Source(List(ByteString(events1AsStr), ByteString(events2AsStr)))
-      val watchEventSource = BytesToWatchEventSource[ReplicationController](bytesSource, 1000)
+      val watchEventSource = BytesToWatchEventSource[ReplicationController](client, bytesSource, 1000, None)
 
       val eventSink = Sink.seq[WatchEvent[ReplicationController]]
       val run: Future[Seq[WatchEvent[ReplicationController]]] = watchEventSource.runWith(eventSink)
@@ -102,7 +106,7 @@ class BytesToWatchEventSourceSpec extends Specification {
     val event4AsStr = """{"type":"MODIFIED","object":{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"frontend","namespace":"default","selfLink":"/api/v1/namespaces/default/replicationcontrollers/frontend","uid":"246f12b6-719b-11e5-89ae-0800279dd272","resourceVersion":"12803","generation":2,"creationTimestamp":"2015-10-13T11:11:24Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":0,"observedGeneration":2}}}
 """
     val bytesSource = Source(List(ByteString(event1AsStr), ByteString(event2AsStr), ByteString(event3AsStr), ByteString(event4AsStr)))
-    val watchEventSource = BytesToWatchEventSource[ReplicationController](bytesSource, 1000)
+    val watchEventSource = BytesToWatchEventSource[ReplicationController](client, bytesSource, 1000, None)
 
     val eventSink = Sink.seq[WatchEvent[ReplicationController]]
     val run: Future[Seq[WatchEvent[ReplicationController]]] = watchEventSource.runWith(eventSink)
@@ -114,5 +118,39 @@ class BytesToWatchEventSourceSpec extends Specification {
     rcSeq(1)._object.status.get.replicas mustEqual 2
     rcSeq(2)._object.status.get.replicas mustEqual 1
     rcSeq(3)._object.status.get.replicas mustEqual 0
+  }
+
+  "Four chunks, containing two ERROR events in the middle, can be correctly enumerated" >> {
+    // normally the objects in error events are Status kinds
+    val errorObject1Str = """{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"some sort of error","reason":"who knows","code":410}"""
+    val errorObject2Str = """{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"some other sort of error","reason":"who knows","code":403}"""
+
+    val event1AsStr =
+      """{"type":"MODIFIED","object":{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"frontend","namespace":"default","selfLink":"/api/v1/namespaces/default/replicationcontrollers/frontend","uid":"246f12b6-719b-11e5-89ae-0800279dd272","resourceVersion":"12803","generation":2,"creationTimestamp":"2015-10-13T11:11:24Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":3,"observedGeneration":2}}}
+"""
+    val event2AsStr =
+      s"""{"type":"ERROR","object":$errorObject1Str}"""
+    val event3AsStr =
+      s"""{"type":"ERROR","object":$errorObject2Str}"""
+    val event4AsStr =
+      """{"type":"MODIFIED","object":{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"frontend","namespace":"default","selfLink":"/api/v1/namespaces/default/replicationcontrollers/frontend","uid":"246f12b6-719b-11e5-89ae-0800279dd272","resourceVersion":"12803","generation":2,"creationTimestamp":"2015-10-13T11:11:24Z","labels":{"name":"frontend"}},"spec":{"replicas":0,"selector":{"name":"frontend"},"template":{"metadata":{"name":"frontend","namespace":"default","creationTimestamp":null,"labels":{"name":"frontend"}},"spec":{"containers":[{"name":"php-redis","image":"kubernetes/example-guestbook-php-redis:v2","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/var/log/termination","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"Default"}}},"status":{"replicas":0,"observedGeneration":2}}}
+"""
+    val errors = mutable.ListBuffer[String]()
+    val errorHandler = (error: String) => errors.addOne(error)
+    val bytesSource = Source(List(ByteString(event1AsStr), ByteString(event2AsStr), ByteString(event3AsStr), ByteString(event4AsStr)))
+    val watchEventSource = BytesToWatchEventSource[ReplicationController](client, bytesSource, 1000, Some(errorHandler))
+
+    val eventSink = Sink.seq[WatchEvent[ReplicationController]]
+    val run: Future[Seq[WatchEvent[ReplicationController]]] = watchEventSource.runWith(eventSink)
+
+    val rcSeq = Await.result(run, Duration.Inf)
+
+    rcSeq.length mustEqual 2
+    rcSeq(0)._object.status.get.replicas mustEqual 3
+    rcSeq(1)._object.status.get.replicas mustEqual 0
+
+    errors.length mustEqual 2
+    errors(0) mustEqual errorObject1Str
+    errors(1) mustEqual errorObject2Str
   }
 }

--- a/client/src/test/scala/skuber/api/WatchSourceSpec.scala
+++ b/client/src/test/scala/skuber/api/WatchSourceSpec.scala
@@ -50,7 +50,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -94,7 +94,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -143,7 +143,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), Some(name), ListOptions(resourceVersion= Some("12802"),timeoutSeconds = Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), Some(name), ListOptions(resourceVersion= Some("12802"),timeoutSeconds = Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -191,7 +191,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), Some(name), ListOptions(timeoutSeconds = Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), Some(name), ListOptions(timeoutSeconds = Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -238,7 +238,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -277,7 +277,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -311,7 +311,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -344,7 +344,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -378,7 +378,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(responses), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -413,7 +413,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(new TcpIdleTimeoutException("timeout", 10.seconds)), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(new TcpIdleTimeoutException("timeout", 10.seconds)), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()
@@ -447,7 +447,7 @@ class WatchSourceSpec extends Specification with MockitoSugar {
       )
 
       val (switch, downstream) =
-        WatchSource[ReplicationController](client, mockPool(new ConnectException(s"Connect timeout of 10s expired")), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000)
+        WatchSource[ReplicationController](client, mockPool(new ConnectException(s"Connect timeout of 10s expired")), None, ListOptions(resourceVersion=Some("12802"), timeoutSeconds=Some(1)), 10000, None)
           .viaMat(KillSwitches.single)(Keep.right)
           .toMat(TestSink.probe)(Keep.both)
           .run()


### PR DESCRIPTION
ERROR watch events will be handled differently to non-error events - instead of attempting to parse the object in the event and emitting it in the stream along with other events to the client, it will be either simply logged or optionally sent to a specified error handler function. 