### PR TITLE
Added SubjectAccessReview API

### DIFF
--- a/client/src/main/scala/skuber/authorization/SubjectAccessReview.scala
+++ b/client/src/main/scala/skuber/authorization/SubjectAccessReview.scala
@@ -1,0 +1,81 @@
+package skuber.authorization
+
+import skuber.ResourceSpecification.{ Names, Scope }
+import skuber.rbac.rbacAPIVersion
+import skuber.{ NonCoreResourceSpecification, ObjectMeta, ObjectResource, ResourceDefinition }
+
+case class SubjectAccessReviewSpec(
+    extra: Map[String, String] = Map.empty,
+    groups: List[String] = Nil,
+    nonResourceAttributes: Option[NonResourceAttributes] = None,
+    resourceAttributes: Option[ResourceAttributes] = None,
+    uid: Option[String] = None,
+    user: Option[String] = None
+)
+
+case class NonResourceAttributes(path: String, verb: String)
+
+case class ResourceAttributes(
+    group: String,
+    version: String,
+    resource: String,
+    verb: String,
+    subresource: Option[String] = None,
+    namespace: Option[String] = None,
+    name: Option[String] = None
+)
+
+case class SubjectAccessReviewStatus(
+    allowed: Boolean,
+    denied: Option[Boolean] = None,
+    evaluationError: Option[String] = None,
+    reason: Option[String] = None
+)
+
+case class SubjectAccessReview(
+    kind: String = "SubjectAccessReview",
+    apiVersion: String = authorizationAPIVersion,
+    metadata: ObjectMeta = ObjectMeta(),
+    spec: SubjectAccessReviewSpec,
+    status: Option[SubjectAccessReviewStatus] = None,
+) extends ObjectResource
+
+object SubjectAccessReview {
+  implicit val subjectAccessReviewDef = new ResourceDefinition[SubjectAccessReview] {
+    def spec = NonCoreResourceSpecification (
+      apiGroup="authorization.k8s.io",
+      version="v1",
+      scope = Scope.Cluster,
+      names=Names(
+        plural = "subjectaccessreviews",
+        singular = "subjectaccessreview",
+        kind = "SubjectAccessReview",
+        shortNames = Nil
+      )
+    )
+  }
+}
+
+case class LocalSubjectAccessReview(
+                                kind: String = "LocalSubjectAccessReview",
+                                apiVersion: String = authorizationAPIVersion,
+                                metadata: ObjectMeta = ObjectMeta(),
+                                spec: SubjectAccessReviewSpec,
+                                status: Option[SubjectAccessReviewStatus] = None,
+                              ) extends ObjectResource
+
+object LocalSubjectAccessReview {
+  implicit val localSubjectAccessReviewDef = new ResourceDefinition[LocalSubjectAccessReview] {
+    def spec = NonCoreResourceSpecification (
+      apiGroup="authorization.k8s.io",
+      version="v1",
+      scope = Scope.Namespaced,
+      names=Names(
+        plural = "localsubjectaccessreviews",
+        singular = "localsubjectaccessreview",
+        kind = "LocalSubjectAccessReview",
+        shortNames = Nil
+      )
+    )
+  }
+}

--- a/client/src/main/scala/skuber/authorization/package.scala
+++ b/client/src/main/scala/skuber/authorization/package.scala
@@ -1,0 +1,5 @@
+package skuber
+
+package object authorization {
+  val authorizationAPIVersion = "authorization.k8s.io/v1"
+}

--- a/client/src/main/scala/skuber/json/authorization/format/package.scala
+++ b/client/src/main/scala/skuber/json/authorization/format/package.scala
@@ -1,0 +1,53 @@
+package skuber.json.authorization
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.authorization._
+import skuber.json.format._ // reuse some core formatters
+
+package object format {
+
+  implicit val nonResourceAttributesFormat: Format[NonResourceAttributes] = (
+    (JsPath \ "path").format[String] and
+      (JsPath \ "verb").format[String]
+    ) (NonResourceAttributes.apply, unlift(NonResourceAttributes.unapply))
+
+  implicit val resourceAttributesFormat: Format[ResourceAttributes] = (
+    (JsPath \ "group").format[String] and
+      (JsPath \ "version").format[String] and
+      (JsPath \ "resource").format[String] and
+      (JsPath \ "verb").format[String] and
+      (JsPath \ "subresource").formatNullable[String] and
+      (JsPath \ "namespace").formatNullable[String] and
+      (JsPath \ "name").formatNullable[String]
+    ) (ResourceAttributes.apply, unlift(ResourceAttributes.unapply))
+
+  implicit val subjectAccessReviewSpecFormat: Format[SubjectAccessReviewSpec] = (
+    (JsPath \ "extra").formatMaybeEmptyMap[String] and
+    (JsPath \ "groups").formatMaybeEmptyList[String] and
+    (JsPath \ "nonResourceAttributes").formatNullable[NonResourceAttributes] and
+    (JsPath \ "resourceAttributes").formatNullable[ResourceAttributes] and
+    (JsPath \ "uid").formatNullable[String] and
+    (JsPath \ "user").formatNullable[String]
+  )(SubjectAccessReviewSpec.apply, unlift(SubjectAccessReviewSpec.unapply))
+
+  implicit val subjectAccessReviewStatusFormat: Format[SubjectAccessReviewStatus] = (
+    (JsPath \ "allowed").format[Boolean] and
+    (JsPath \ "denied").formatNullable[Boolean] and
+    (JsPath \ "evaluationError").formatNullable[String] and
+    (JsPath \ "reason").formatNullable[String]
+  )(SubjectAccessReviewStatus.apply, unlift(SubjectAccessReviewStatus.unapply))
+
+  implicit val subjectAccessReviewFormat: Format[SubjectAccessReview] = (
+    objFormat and
+    (JsPath \ "spec").format[SubjectAccessReviewSpec] and
+    (JsPath \ "status").formatNullable[SubjectAccessReviewStatus]
+  )(SubjectAccessReview.apply, unlift(SubjectAccessReview.unapply))
+
+  implicit val localSubjectAccessReviewFormat: Format[LocalSubjectAccessReview] = (
+    objFormat and
+    (JsPath \ "spec").format[SubjectAccessReviewSpec] and
+    (JsPath \ "status").formatNullable[SubjectAccessReviewStatus]
+  )(LocalSubjectAccessReview.apply, unlift(LocalSubjectAccessReview.unapply))
+
+}

--- a/client/src/main/scala/skuber/rbac/ClusterRole.scala
+++ b/client/src/main/scala/skuber/rbac/ClusterRole.scala
@@ -18,7 +18,7 @@ object ClusterRole {
   implicit val crDef = new ResourceDefinition[ClusterRole] {
     def spec = NonCoreResourceSpecification (
       apiGroup="rbac.authorization.k8s.io",
-      version="v1beta1",
+      version="v1",
       scope = Scope.Cluster,
       names=Names(
         plural = "clusterroles",

--- a/client/src/main/scala/skuber/rbac/ClusterRoleBinding.scala
+++ b/client/src/main/scala/skuber/rbac/ClusterRoleBinding.scala
@@ -18,7 +18,7 @@ object ClusterRoleBinding {
   implicit val crDef = new ResourceDefinition[ClusterRoleBinding] {
     def spec = NonCoreResourceSpecification (
       apiGroup="rbac.authorization.k8s.io",
-      version="v1beta1",
+      version="v1",
       scope = Scope.Cluster,
       names=Names(
         plural = "clusterrolebindings",

--- a/client/src/main/scala/skuber/rbac/Role.scala
+++ b/client/src/main/scala/skuber/rbac/Role.scala
@@ -17,7 +17,7 @@ object Role {
   implicit val roleDef = new ResourceDefinition[Role] {
     def spec = NonCoreResourceSpecification (
       apiGroup="rbac.authorization.k8s.io",
-      version="v1beta1",
+      version="v1",
       scope = Scope.Namespaced,
       names=Names(
         plural = "roles",

--- a/client/src/main/scala/skuber/rbac/RoleBinding.scala
+++ b/client/src/main/scala/skuber/rbac/RoleBinding.scala
@@ -18,7 +18,7 @@ object RoleBinding {
 
   def specification = NonCoreResourceSpecification (
     apiGroup="rbac.authorization.k8s.io",
-    version="v1beta1",
+    version="v1",
     scope = Scope.Namespaced,
     names=Names(
       plural = "rolebindings",

--- a/client/src/main/scala/skuber/rbac/package.scala
+++ b/client/src/main/scala/skuber/rbac/package.scala
@@ -7,7 +7,7 @@ import skuber.json.rbac.format._
   * Created by jordan on 1/13/17.
   */
 package object rbac {
-  val rbacAPIVersion = "rbac.authorization.k8s.io/v1beta1"
+  val rbacAPIVersion = "rbac.authorization.k8s.io/v1"
 
   type ClusterRoleList = ListResource[ClusterRole]
   type ClusterRoleBindingList = ListResource[ClusterRoleBinding]

--- a/client/src/test/scala/skuber/authorization/LocalSubjectAccessReviewSpec.scala
+++ b/client/src/test/scala/skuber/authorization/LocalSubjectAccessReviewSpec.scala
@@ -1,0 +1,31 @@
+package skuber.authorization
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+import skuber.json.authorization.format._
+
+class LocalSubjectAccessReviewSpec extends Specification {
+
+  "LocalSubjectAccessReview can be round tripped" >> {
+    val sar = LocalSubjectAccessReview(
+      spec = SubjectAccessReviewSpec(
+        user = Some("user"),
+        groups = List("group1", "group2"),
+        resourceAttributes = Some(ResourceAttributes(
+          group = "apps",
+          version = "v1",
+          resource = "Deployment",
+          verb = "create"
+        ))
+      ),
+      status = Some(SubjectAccessReviewStatus(
+        allowed = false,
+        denied = Some(true),
+        reason = Some("User doesn't have access to that resource")
+      ))
+    )
+    Json.toJson(sar).as[LocalSubjectAccessReview] mustEqual sar
+  }
+
+}


### PR DESCRIPTION
Fixes #353.

Also, I updated the rbac API version to v1, since it's been available since Kubernetes 1.8, and v1beta1 was removed in 1.22.