### PR TITLE
add rwop to pvc access mode

### DIFF
--- a/client/src/main/scala/skuber/PersistentVolume.scala
+++ b/client/src/main/scala/skuber/PersistentVolume.scala
@@ -36,7 +36,7 @@ object PersistentVolume {
 
   object AccessMode extends Enumeration {
     type AccessMode = Value
-    val ReadWriteOnce,ReadOnlyMany,ReadWriteMany = Value
+    val ReadWriteOnce,ReadWriteOncePod,ReadOnlyMany,ReadWriteMany = Value
   }
   
   object Phase extends Enumeration {

--- a/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
+++ b/client/src/test/scala/skuber/json/VolumeFormatSpec.scala
@@ -24,7 +24,7 @@ class VolumeReadWriteSpec extends Specification {
           name = "mypvc"
         ),
         spec = Some(PersistentVolumeClaim.Spec(
-          accessModes = List(PersistentVolume.AccessMode.ReadWriteOnce),
+          accessModes = List(PersistentVolume.AccessMode.ReadWriteOnce, PersistentVolume.AccessMode.ReadWriteOncePod),
           resources = Some(Resource.Requirements(limits=Map("storage" -> "30Gi"))),
           volumeName = Some("volume-name"),
           storageClassName = Some("a-storage-class-name"),


### PR DESCRIPTION
2.6.x seems to still be maintained. I can make another 3.x PR if you'd like 