### PR TITLE
Server-Side Apply Feature Implementation

### DIFF
--- a/akka/src/main/scala/skuber/akkaclient/impl/AkkaKubernetesClientImpl.scala
+++ b/akka/src/main/scala/skuber/akkaclient/impl/AkkaKubernetesClientImpl.scala
@@ -486,7 +486,7 @@ class AkkaKubernetesClientImpl private[akkaclient] (
 
   override def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(
     implicit writes: Writes[AC], fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Future[O] = {
-    val contentType = CustomMediaTypes.`application/apply-patch+json`
+    val contentType = CustomMediaTypes.`application/apply-patch+yaml`
     val queryMap = scala.collection.mutable.Map("fieldManager" -> options.fieldManager)
     if (options.force) queryMap += ("force" -> "true")
     val query = Some(Uri.Query(queryMap.toMap))

--- a/akka/src/main/scala/skuber/akkaclient/impl/AkkaKubernetesClientImpl.scala
+++ b/akka/src/main/scala/skuber/akkaclient/impl/AkkaKubernetesClientImpl.scala
@@ -17,6 +17,7 @@ import skuber.akkaclient.watch.{AkkaWatcherImpl, LongPollingPool}
 import skuber.akkaclient.exec.PodExecImpl
 import skuber.api.client._
 import skuber.api.patch._
+import skuber.model.ac.ApplyConfiguration
 import skuber.api.security.TLS
 import PlayJsonSupportForAkkaHttp._
 import skuber.json.format.apiobj.statusReads
@@ -478,6 +479,23 @@ class AkkaKubernetesClientImpl private[akkaclient] (
     for {
       requestEntity <- marshal.to[RequestEntity]
       httpRequest <- buildRequest(HttpMethods.PATCH, rd, Some(name), namespaceOverride = namespace)
+      requestWithEntity = httpRequest.withEntity(requestEntity.withContentType(contentType))
+      newOrUpdatedResource <- makeRequestReturningObjectResource[O](requestWithEntity)
+    } yield newOrUpdatedResource
+  }
+
+  override def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(
+    implicit writes: Writes[AC], fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Future[O] = {
+    val contentType = CustomMediaTypes.`application/apply-patch+json`
+    val queryMap = scala.collection.mutable.Map("fieldManager" -> options.fieldManager)
+    if (options.force) queryMap += ("force" -> "true")
+    val query = Some(Uri.Query(queryMap.toMap))
+    logInfo(logConfig.logRequestBasicMetadata, s"Requesting apply of resource: { name:${applyConfig.name}, fieldManager:${options.fieldManager} ... }")
+    logInfo(logConfig.logRequestFullObjectResource, s" Marshal and send: ${applyConfig.toString}")
+    val marshal = Marshal(applyConfig)
+    for {
+      requestEntity <- marshal.to[RequestEntity]
+      httpRequest <- buildRequest(HttpMethods.PATCH, rd, Some(applyConfig.name), query = query)
       requestWithEntity = httpRequest.withEntity(requestEntity.withContentType(contentType))
       newOrUpdatedResource <- makeRequestReturningObjectResource[O](requestWithEntity)
     } yield newOrUpdatedResource

--- a/akka/src/main/scala/skuber/akkaclient/package.scala
+++ b/akka/src/main/scala/skuber/akkaclient/package.scala
@@ -20,7 +20,7 @@ package object akkaclient {
   object CustomMediaTypes {
     val `application/merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("merge-patch+json", HttpCharsets.`UTF-8`)
     val `application/strategic-merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("strategic-merge-patch+json", HttpCharsets.`UTF-8`)
-    val `application/apply-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("apply-patch+json", HttpCharsets.`UTF-8`)
+    val `application/apply-patch+yaml`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("apply-patch+yaml", HttpCharsets.`UTF-8`)
   }
 
   type Pool[T] = Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed]

--- a/akka/src/main/scala/skuber/akkaclient/package.scala
+++ b/akka/src/main/scala/skuber/akkaclient/package.scala
@@ -20,6 +20,7 @@ package object akkaclient {
   object CustomMediaTypes {
     val `application/merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("merge-patch+json", HttpCharsets.`UTF-8`)
     val `application/strategic-merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("strategic-merge-patch+json", HttpCharsets.`UTF-8`)
+    val `application/apply-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("apply-patch+json", HttpCharsets.`UTF-8`)
   }
 
   type Pool[T] = Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed]

--- a/cats-it/src/test/scala/skuber/catseffect/CatsServerSideApplySpec.scala
+++ b/cats-it/src/test/scala/skuber/catseffect/CatsServerSideApplySpec.scala
@@ -1,0 +1,83 @@
+package skuber.catseffect
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import skuber.api.client.{ApplyOptions, DeleteOptions, DeletePropagation, LoggingContext, RequestLoggingContext}
+import skuber.json.format.*
+import skuber.model.LabelSelector
+import skuber.model.LabelSelector.dsl.*
+import skuber.model.ac.apps.v1.{DeploymentApplyConfig, DeploymentSpecApplyConfig}
+import skuber.model.ac.{ContainerApplyConfig, PodSpecApplyConfig, PodTemplateSpecApplyConfig}
+import skuber.model.apps.v1.Deployment
+import skuber.catseffect.TestHelpers.*
+
+import scala.concurrent.duration.*
+
+class CatsServerSideApplySpec extends CatsEffectSuite:
+  given LoggingContext = RequestLoggingContext()
+  override def munitIOTimeout: Duration = 10.minutes
+
+  val client = ResourceFunFixture(CatsKubernetesClient.resource[IO])
+
+  client.test("server-side apply creates and updates a deployment") { k8s =>
+    val name = java.util.UUID.randomUUID().toString
+    val fieldManager = "skuber-ssa-test"
+
+    val initialConfig = DeploymentApplyConfig(name)
+      .addLabel("app" -> name)
+      .withSpec(DeploymentSpecApplyConfig()
+        .withReplicas(1)
+        .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", name)))
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addLabel("app" -> name)
+          .withPodSpec(PodSpecApplyConfig()
+            .addContainer(ContainerApplyConfig("nginx", "nginx:1.25").exposePort(80))
+          )
+        )
+      )
+
+    val updatedConfig = DeploymentApplyConfig(name)
+      .addLabel("app" -> name)
+      .withSpec(DeploymentSpecApplyConfig()
+        .withReplicas(2)
+        .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", name)))
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addLabel("app" -> name)
+          .withPodSpec(PodSpecApplyConfig()
+            .addContainer(ContainerApplyConfig("nginx", "nginx:1.27").exposePort(80))
+          )
+        )
+      )
+
+    val cleanup =
+      k8s.deleteWithOptions[Deployment](name, DeleteOptions(propagationPolicy = Some(DeletePropagation.Foreground)))
+        .flatMap(_ => retryUntilGone(k8s.get[Deployment](name), retries = 40, delay = 3.seconds))
+        .handleErrorWith(_ => IO.unit)
+
+    val test = for
+      created <- k8s.apply[Deployment, DeploymentApplyConfig](initialConfig, ApplyOptions(fieldManager = fieldManager))
+        .map(_.getOrElse(fail("Initial apply failed")))
+      _ = assertEquals(created.name, name)
+      _ = assertEquals(created.spec.flatMap(_.replicas), Some(1))
+
+      _ <- retryUntil(
+        k8s.get[Deployment](name).map(_.exists(_.status.exists(_.availableReplicas >= 1))),
+        retries = 40, delay = 3.seconds, label = "availableReplicas >= 1"
+      )
+
+      updated <- k8s.apply[Deployment, DeploymentApplyConfig](updatedConfig, ApplyOptions(fieldManager = fieldManager))
+        .map(_.getOrElse(fail("Update apply failed")))
+      _ = assertEquals(updated.spec.flatMap(_.replicas), Some(2))
+      _ = assertEquals(
+        updated.spec.flatMap(_.template.spec).flatMap(_.containers.headOption).map(_.image),
+        Some("nginx:1.27")
+      )
+
+      _ <- retryUntil(
+        k8s.get[Deployment](name).map(_.exists(_.status.exists(_.availableReplicas >= 2))),
+        retries = 40, delay = 3.seconds, label = "availableReplicas >= 2"
+      )
+    yield ()
+
+    test.guarantee(cleanup)
+  }

--- a/cats-it/src/test/scala/skuber/catseffect/CatsServerSideApplySpec.scala
+++ b/cats-it/src/test/scala/skuber/catseffect/CatsServerSideApplySpec.scala
@@ -62,7 +62,7 @@ class CatsServerSideApplySpec extends CatsEffectSuite:
 
       _ <- retryUntil(
         k8s.get[Deployment](name).map(_.exists(_.status.exists(_.availableReplicas >= 1))),
-        retries = 40, delay = 3.seconds, label = "availableReplicas >= 1"
+        retries = 40, delay = 5.seconds, label = "availableReplicas >= 1"
       )
 
       updated <- k8s.apply[Deployment, DeploymentApplyConfig](updatedConfig, ApplyOptions(fieldManager = fieldManager))
@@ -75,7 +75,7 @@ class CatsServerSideApplySpec extends CatsEffectSuite:
 
       _ <- retryUntil(
         k8s.get[Deployment](name).map(_.exists(_.status.exists(_.availableReplicas >= 2))),
-        retries = 40, delay = 3.seconds, label = "availableReplicas >= 2"
+        retries = 40, delay = 5.seconds, label = "availableReplicas >= 2"
       )
     yield ()
 

--- a/cats/src/main/scala/skuber/catseffect/CatsKubernetesClient.scala
+++ b/cats/src/main/scala/skuber/catseffect/CatsKubernetesClient.scala
@@ -8,8 +8,9 @@ import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.jdkhttpclient.JdkWSClient
 import play.api.libs.json.{Format, Writes}
 import skuber.api.Configuration
-import skuber.api.client.{K8SException, LoggingConfig, LoggingContext, WatchEvent, WatchParameters, ListOptions, DeleteOptions}
+import skuber.api.client.{K8SException, LoggingConfig, LoggingContext, WatchEvent, WatchParameters, ListOptions, DeleteOptions, ApplyOptions}
 import skuber.api.patch.Patch
+import skuber.model.ac.ApplyConfiguration
 import skuber.internal.TlsHelper
 import skuber.catseffect.internal.CatsKubernetesClientImpl
 import skuber.catseffect.internal.http4s.Http4sBackend
@@ -31,6 +32,7 @@ trait CatsKubernetesClient[F[_]]:
   def getScale[O <: ObjectResource](name: String)(using ResourceDefinition[O], Scale.SubresourceSpec[O], LoggingContext): F[Either[K8SException, Scale]]
   def updateScale[O <: ObjectResource](name: String, scale: Scale)(using ResourceDefinition[O], Scale.SubresourceSpec[O], LoggingContext): F[Either[K8SException, Scale]]
   def patch[P <: Patch, O <: ObjectResource](name: String, patchData: P, namespace: Option[String] = None)(using Writes[P], Format[O], ResourceDefinition[O], LoggingContext): F[Either[K8SException, O]]
+  def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(using Writes[AC], Format[O], ResourceDefinition[O], LoggingContext): F[Either[K8SException, O]]
   def watch[O <: ObjectResource](params: WatchParameters = WatchParameters())(using Format[O], ResourceDefinition[O], LoggingContext): Stream[F, Either[K8SException, WatchEvent[O]]]
   def getWatcher[O <: ObjectResource]: CatsWatcher[F, O]
   def getPodLogStream(name: String, queryParams: Pod.LogQueryParams = Pod.LogQueryParams(), namespace: Option[String] = None)(using LoggingContext): Stream[F, Byte]

--- a/cats/src/main/scala/skuber/catseffect/internal/CatsKubernetesClientImpl.scala
+++ b/cats/src/main/scala/skuber/catseffect/internal/CatsKubernetesClientImpl.scala
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory
 import play.api.libs.json.{Format, Json, Writes}
 import skuber.api.client.*
 import skuber.api.patch.{Patch, StrategicMergePatchStrategy, JsonMergePatchStrategy, JsonPatchStrategy}
+import skuber.model.ac.ApplyConfiguration
 import skuber.catseffect.{CatsKubernetesClient, CatsWatcher, ExecOutput}
 import skuber.internal.{AuthInterceptor, HttpMethod, K8sRequest, K8sResponse, UrlBuilder}
 import skuber.json.format.deleteOptionsFmt
@@ -155,6 +156,14 @@ private[catseffect] class CatsKubernetesClientImpl[F[_]: Async](
       case JsonPatchStrategy => "application/json-patch+json"
     val body = PlayJsonBridge.encode(patchData)
     val req = K8sRequest(method = HttpMethod.Patch, url = url, body = Some(body), headers = Map("Content-Type" -> contentType))
+    executeRequest(req).map(parseResponse[O])
+
+  override def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(using Writes[AC], Format[O], ResourceDefinition[O], LoggingContext): F[Either[K8SException,O]] =
+    val rd = summon[ResourceDefinition[O]]
+    val url = UrlBuilder.resourceUrl(clusterServer, namespace, rd, Some(applyConfig.name))
+    val body = PlayJsonBridge.encode(applyConfig)
+    val queryParams = Seq("fieldManager" -> options.fieldManager) ++ (if options.force then Seq("force" -> "true") else Seq.empty)
+    val req = K8sRequest(method = HttpMethod.Patch, url = url, body = Some(body), headers = Map("Content-Type" -> "application/apply-patch+json"), queryParams = queryParams)
     executeRequest(req).map(parseResponse[O])
 
   override def watch[O <: ObjectResource](params: WatchParameters = WatchParameters())(using Format[O], ResourceDefinition[O], LoggingContext): Stream[F, Either[K8SException, WatchEvent[O]]] =

--- a/cats/src/main/scala/skuber/catseffect/internal/CatsKubernetesClientImpl.scala
+++ b/cats/src/main/scala/skuber/catseffect/internal/CatsKubernetesClientImpl.scala
@@ -163,7 +163,7 @@ private[catseffect] class CatsKubernetesClientImpl[F[_]: Async](
     val url = UrlBuilder.resourceUrl(clusterServer, namespace, rd, Some(applyConfig.name))
     val body = PlayJsonBridge.encode(applyConfig)
     val queryParams = Seq("fieldManager" -> options.fieldManager) ++ (if options.force then Seq("force" -> "true") else Seq.empty)
-    val req = K8sRequest(method = HttpMethod.Patch, url = url, body = Some(body), headers = Map("Content-Type" -> "application/apply-patch+json"), queryParams = queryParams)
+    val req = K8sRequest(method = HttpMethod.Patch, url = url, body = Some(body), headers = Map("Content-Type" -> "application/apply-patch+yaml"), queryParams = queryParams)
     executeRequest(req).map(parseResponse[O])
 
   override def watch[O <: ObjectResource](params: WatchParameters = WatchParameters())(using Format[O], ResourceDefinition[O], LoggingContext): Stream[F, Either[K8SException, WatchEvent[O]]] =

--- a/core/src/main/scala/skuber/api/client/KubernetesClient.scala
+++ b/core/src/main/scala/skuber/api/client/KubernetesClient.scala
@@ -2,6 +2,7 @@ package skuber.api.client
 
 import play.api.libs.json.{Format, Writes}
 import skuber.model.{HasStatusSubresource, LabelSelector, ListResource, ObjectResource, Pod, ResourceDefinition, Scale}
+import skuber.model.ac.ApplyConfiguration
 import skuber.api.patch.Patch
 
 import scala.concurrent.{Future, Promise}
@@ -235,6 +236,9 @@ trait BaseKubernetesClient {
     */
   def patch[P <: Patch, O <: ObjectResource](name: String, patchData: P, namespace: Option[String] = None)
       (implicit patchfmt: Writes[P], fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext = RequestLoggingContext()): Future[O]
+
+  def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(
+    implicit writes: Writes[AC], fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Future[O]
 
   /**
     * Return list of API versions supported by the server

--- a/core/src/main/scala/skuber/api/client/package.scala
+++ b/core/src/main/scala/skuber/api/client/package.scala
@@ -95,6 +95,11 @@ package object client {
     }
   }
 
+  case class ApplyOptions(
+    fieldManager: String,
+    force: Boolean = false
+  )
+
   final val sysProps = new SystemProperties
 
   // Certificates and keys can be specified in configuration either as paths to files or embedded PEM data
@@ -302,7 +307,7 @@ package object client {
     def apply(): RequestLoggingContext = new RequestLoggingContext(UUID.randomUUID.toString)
   }
 
-  class K8SException(val status: Status) extends RuntimeException(status.toString) { // we throw this when we receive a non-OK response
+  class K8SException(val status: Status) extends RuntimeException(status.message.getOrElse(status.code.map(_.toString).getOrElse(status.toString))) {
     def code: Option[Int]       = status.code
     def isNotFound: Boolean     = code.contains(404)
     def isConflict: Boolean     = code.contains(409)

--- a/core/src/main/scala/skuber/model/ac/ConfigMapApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/ConfigMapApplyConfig.scala
@@ -1,0 +1,32 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format.mapStringByteArrayFormat
+
+case class ConfigMapApplyConfig(
+  kind: String = "ConfigMap",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  data: Option[Map[String, String]] = None,
+  binaryData: Option[Map[String, Array[Byte]]] = None
+) extends ApplyConfiguration[ConfigMap] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withData(d: Map[String, String]): ConfigMapApplyConfig = copy(data = Some(d))
+  def addData(kv: (String, String)): ConfigMapApplyConfig = copy(data = Some(data.getOrElse(Map.empty) + kv))
+  def withBinaryData(d: Map[String, Array[Byte]]): ConfigMapApplyConfig = copy(binaryData = Some(d))
+}
+
+object ConfigMapApplyConfig {
+  def apply(name: String): ConfigMapApplyConfig =
+    ConfigMapApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ConfigMapApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "data").writeNullable[Map[String, String]] and
+    (JsPath \ "binaryData").writeNullable[Map[String, Array[Byte]]]
+  )(c => (c.kind, c.apiVersion, c.metadata, c.data, c.binaryData))
+}

--- a/core/src/main/scala/skuber/model/ac/ContainerApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/ContainerApplyConfig.scala
@@ -1,0 +1,121 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class ContainerApplyConfig(
+  name: Option[String] = None,
+  image: Option[String] = None,
+  command: Option[List[String]] = None,
+  args: Option[List[String]] = None,
+  workingDir: Option[String] = None,
+  ports: Option[List[Container.Port]] = None,
+  env: Option[List[EnvVar]] = None,
+  resources: Option[Resource.Requirements] = None,
+  volumeMounts: Option[List[Volume.Mount]] = None,
+  livenessProbe: Option[Probe] = None,
+  readinessProbe: Option[Probe] = None,
+  lifecycle: Option[Lifecycle] = None,
+  terminationMessagePath: Option[String] = None,
+  terminationMessagePolicy: Option[Container.TerminationMessagePolicy.Value] = None,
+  imagePullPolicy: Option[Container.PullPolicy.Value] = None,
+  securityContext: Option[SecurityContext] = None,
+  envFrom: Option[List[EnvFromSource]] = None,
+  stdin: Option[Boolean] = None,
+  stdinOnce: Option[Boolean] = None,
+  tty: Option[Boolean] = None,
+  volumeDevices: Option[List[Volume.Device]] = None,
+  startupProbe: Option[Probe] = None
+) {
+  def exposePort(p: Container.Port): ContainerApplyConfig = copy(ports = Some(p :: ports.getOrElse(Nil)))
+  def exposePort(port: Int): ContainerApplyConfig = exposePort(Container.Port(containerPort = port))
+
+  def setEnvVar(n: String, v: String): ContainerApplyConfig = {
+    val envVar = EnvVar(n, EnvVar.StringValue(v))
+    copy(env = Some(env.getOrElse(Nil) :+ envVar))
+  }
+
+  def setEnvVarFromField(n: String, fieldPath: String): ContainerApplyConfig = {
+    val envVar = EnvVar(n, EnvVar.FieldRef(fieldPath))
+    copy(env = Some(env.getOrElse(Nil) :+ envVar))
+  }
+
+  def withWorkingDir(wd: String): ContainerApplyConfig = copy(workingDir = Some(wd))
+  def withArgs(arg: String*): ContainerApplyConfig = copy(args = Some(arg.toList))
+  def withEntrypoint(cmd: String*): ContainerApplyConfig = copy(command = Some(cmd.toList))
+
+  def withTerminationMessagePath(path: String): ContainerApplyConfig = copy(terminationMessagePath = Some(path))
+  def withTerminationMessagePolicy(policy: Container.TerminationMessagePolicy.Value): ContainerApplyConfig =
+    copy(terminationMessagePolicy = Some(policy))
+
+  def limitCPU(cpu: Resource.Quantity): ContainerApplyConfig = addResourceLimit(Resource.cpu, cpu)
+  def limitMemory(mem: Resource.Quantity): ContainerApplyConfig = addResourceLimit(Resource.memory, mem)
+  def addResourceLimit(name: String, limit: Resource.Quantity): ContainerApplyConfig = {
+    val currResources = resources.getOrElse(Resource.Requirements())
+    val newLimits = currResources.limits + (name -> limit)
+    copy(resources = Some(Resource.Requirements(newLimits, currResources.requests)))
+  }
+
+  def requestCPU(cpu: Resource.Quantity): ContainerApplyConfig = addResourceRequest(Resource.cpu, cpu)
+  def requestMemory(mem: Resource.Quantity): ContainerApplyConfig = addResourceRequest(Resource.memory, mem)
+  def addResourceRequest(name: String, req: Resource.Quantity): ContainerApplyConfig = {
+    val currResources = resources.getOrElse(Resource.Requirements())
+    val newReqs = currResources.requests + (name -> req)
+    copy(resources = Some(Resource.Requirements(currResources.limits, newReqs)))
+  }
+
+  def mount(name: String, path: String, readOnly: Boolean = false): ContainerApplyConfig =
+    copy(volumeMounts = Some(Volume.Mount(name, path, readOnly) :: volumeMounts.getOrElse(Nil)))
+
+  def withImagePullPolicy(policy: Container.PullPolicy.Value): ContainerApplyConfig =
+    copy(imagePullPolicy = Some(policy))
+
+  def withLivenessProbe(probe: Probe): ContainerApplyConfig = copy(livenessProbe = Some(probe))
+  def withReadinessProbe(probe: Probe): ContainerApplyConfig = copy(readinessProbe = Some(probe))
+  def withStartupProbe(probe: Probe): ContainerApplyConfig = copy(startupProbe = Some(probe))
+  def withSecurityContext(sc: SecurityContext): ContainerApplyConfig = copy(securityContext = Some(sc))
+}
+
+object ContainerApplyConfig {
+
+  def apply(name: String, image: String): ContainerApplyConfig =
+    ContainerApplyConfig(name = Some(name), image = Some(image))
+
+  implicit val writes: OWrites[ContainerApplyConfig] = {
+    val partOne = (
+      (JsPath \ "name").writeNullable[String] and
+      (JsPath \ "image").writeNullable[String] and
+      (JsPath \ "command").writeNullable[List[String]] and
+      (JsPath \ "args").writeNullable[List[String]] and
+      (JsPath \ "workingDir").writeNullable[String] and
+      (JsPath \ "ports").writeNullable[List[Container.Port]] and
+      (JsPath \ "env").writeNullable[List[EnvVar]] and
+      (JsPath \ "resources").writeNullable[Resource.Requirements] and
+      (JsPath \ "volumeMounts").writeNullable[List[Volume.Mount]] and
+      (JsPath \ "livenessProbe").writeNullable[Probe] and
+      (JsPath \ "readinessProbe").writeNullable[Probe]
+    ).tupled
+
+    val partTwo = (
+      (JsPath \ "lifecycle").writeNullable[Lifecycle] and
+      (JsPath \ "terminationMessagePath").writeNullable[String] and
+      (JsPath \ "terminationMessagePolicy").writeNullable[String] and
+      (JsPath \ "imagePullPolicy").writeNullable[String] and
+      (JsPath \ "securityContext").writeNullable[SecurityContext] and
+      (JsPath \ "envFrom").writeNullable[List[EnvFromSource]] and
+      (JsPath \ "stdin").writeNullable[Boolean] and
+      (JsPath \ "stdinOnce").writeNullable[Boolean] and
+      (JsPath \ "tty").writeNullable[Boolean] and
+      (JsPath \ "volumeDevices").writeNullable[List[Volume.Device]] and
+      (JsPath \ "startupProbe").writeNullable[Probe]
+    ).tupled
+
+    OWrites[ContainerApplyConfig] { c =>
+      val p1 = partOne.writes((c.name, c.image, c.command, c.args, c.workingDir, c.ports, c.env, c.resources, c.volumeMounts, c.livenessProbe, c.readinessProbe))
+      val p2 = partTwo.writes((c.lifecycle, c.terminationMessagePath, c.terminationMessagePolicy.map(_.toString), c.imagePullPolicy.map(_.toString), c.securityContext, c.envFrom, c.stdin, c.stdinOnce, c.tty, c.volumeDevices, c.startupProbe))
+      p1.deepMerge(p2)
+    }
+  }
+}

--- a/core/src/main/scala/skuber/model/ac/EndpointsApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/EndpointsApplyConfig.scala
@@ -1,0 +1,31 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class EndpointsApplyConfig(
+  kind: String = "Endpoints",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  subsets: Option[List[Endpoints.Subset]] = None
+) extends ApplyConfiguration[Endpoints] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): EndpointsApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): EndpointsApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): EndpointsApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def addSubset(s: Endpoints.Subset): EndpointsApplyConfig = copy(subsets = Some(s :: subsets.getOrElse(Nil)))
+}
+
+object EndpointsApplyConfig {
+  def apply(name: String): EndpointsApplyConfig =
+    EndpointsApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[EndpointsApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "subsets").writeNullable[List[Endpoints.Subset]]
+  )(e => (e.kind, e.apiVersion, e.metadata, e.subsets))
+}

--- a/core/src/main/scala/skuber/model/ac/LimitRangeApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/LimitRangeApplyConfig.scala
@@ -1,0 +1,43 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class LimitRangeSpecApplyConfig(
+  items: Option[List[LimitRange.Item]] = None
+) {
+  def addItem(item: LimitRange.Item): LimitRangeSpecApplyConfig =
+    copy(items = Some(item :: items.getOrElse(Nil)))
+}
+
+object LimitRangeSpecApplyConfig {
+  implicit val writes: OWrites[LimitRangeSpecApplyConfig] =
+    (JsPath \ "limits").writeNullable[List[LimitRange.Item]].contramap(_.items)
+}
+
+case class LimitRangeApplyConfig(
+  kind: String = "LimitRange",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[LimitRangeSpecApplyConfig] = None
+) extends ApplyConfiguration[LimitRange] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): LimitRangeApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): LimitRangeApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): LimitRangeApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: LimitRangeSpecApplyConfig): LimitRangeApplyConfig = copy(spec = Some(s))
+}
+
+object LimitRangeApplyConfig {
+  def apply(name: String): LimitRangeApplyConfig =
+    LimitRangeApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[LimitRangeApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[LimitRangeSpecApplyConfig]
+  )(l => (l.kind, l.apiVersion, l.metadata, l.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/NamespaceApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/NamespaceApplyConfig.scala
@@ -1,0 +1,27 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+
+case class NamespaceApplyConfig(
+  kind: String = "Namespace",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None
+) extends ApplyConfiguration[Namespace] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): NamespaceApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): NamespaceApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): NamespaceApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+}
+
+object NamespaceApplyConfig {
+  def apply(name: String): NamespaceApplyConfig =
+    NamespaceApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[NamespaceApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig]
+  )(n => (n.kind, n.apiVersion, n.metadata))
+}

--- a/core/src/main/scala/skuber/model/ac/PersistentVolumeClaimApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/PersistentVolumeClaimApplyConfig.scala
@@ -1,0 +1,62 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class PersistentVolumeClaimSpecApplyConfig(
+  accessModes: Option[List[PersistentVolume.AccessMode.AccessMode]] = None,
+  resources: Option[Resource.Requirements] = None,
+  volumeName: Option[String] = None,
+  storageClassName: Option[String] = None,
+  volumeMode: Option[PersistentVolumeClaim.VolumeMode.VolumeMode] = None,
+  selector: Option[LabelSelector] = None
+) {
+  def withAccessModes(modes: List[PersistentVolume.AccessMode.AccessMode]): PersistentVolumeClaimSpecApplyConfig =
+    copy(accessModes = Some(modes))
+  def withStorageClassName(sc: String): PersistentVolumeClaimSpecApplyConfig = copy(storageClassName = Some(sc))
+  def withVolumeName(vn: String): PersistentVolumeClaimSpecApplyConfig = copy(volumeName = Some(vn))
+  def withStorageRequest(storage: Resource.Quantity): PersistentVolumeClaimSpecApplyConfig = {
+    val currResources = resources.getOrElse(Resource.Requirements())
+    val newReqs = currResources.requests + (Resource.storage -> storage)
+    copy(resources = Some(Resource.Requirements(currResources.limits, newReqs)))
+  }
+  def withSelector(s: LabelSelector): PersistentVolumeClaimSpecApplyConfig = copy(selector = Some(s))
+}
+
+object PersistentVolumeClaimSpecApplyConfig {
+  implicit val writes: OWrites[PersistentVolumeClaimSpecApplyConfig] = (
+    (JsPath \ "accessModes").writeNullable[List[String]] and
+    (JsPath \ "resources").writeNullable[Resource.Requirements] and
+    (JsPath \ "volumeName").writeNullable[String] and
+    (JsPath \ "storageClassName").writeNullable[String] and
+    (JsPath \ "volumeMode").writeNullable[String] and
+    (JsPath \ "selector").writeNullable[LabelSelector]
+  )(s => (s.accessModes.map(_.map(_.toString)), s.resources, s.volumeName, s.storageClassName, s.volumeMode.map(_.toString), s.selector))
+}
+
+case class PersistentVolumeClaimApplyConfig(
+  kind: String = "PersistentVolumeClaim",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[PersistentVolumeClaimSpecApplyConfig] = None
+) extends ApplyConfiguration[PersistentVolumeClaim] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): PersistentVolumeClaimApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): PersistentVolumeClaimApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): PersistentVolumeClaimApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: PersistentVolumeClaimSpecApplyConfig): PersistentVolumeClaimApplyConfig = copy(spec = Some(s))
+}
+
+object PersistentVolumeClaimApplyConfig {
+  def apply(name: String): PersistentVolumeClaimApplyConfig =
+    PersistentVolumeClaimApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[PersistentVolumeClaimApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[PersistentVolumeClaimSpecApplyConfig]
+  )(p => (p.kind, p.apiVersion, p.metadata, p.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/PodApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/PodApplyConfig.scala
@@ -1,0 +1,121 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class PodSpecApplyConfig(
+  containers: Option[List[ContainerApplyConfig]] = None,
+  initContainers: Option[List[ContainerApplyConfig]] = None,
+  volumes: Option[List[Volume]] = None,
+  restartPolicy: Option[RestartPolicy.RestartPolicy] = None,
+  terminationGracePeriodSeconds: Option[Int] = None,
+  activeDeadlineSeconds: Option[Int] = None,
+  dnsPolicy: Option[DNSPolicy.DNSPolicy] = None,
+  nodeSelector: Option[Map[String, String]] = None,
+  serviceAccountName: Option[String] = None,
+  nodeName: Option[String] = None,
+  hostNetwork: Option[Boolean] = None,
+  imagePullSecrets: Option[List[LocalObjectReference]] = None,
+  affinity: Option[Pod.Affinity] = None,
+  tolerations: Option[List[Pod.Toleration]] = None,
+  topologySpreadConstraints: Option[List[Pod.TopologySpreadConstraints]] = None,
+  securityContext: Option[PodSecurityContext] = None,
+  hostname: Option[String] = None,
+  hostAliases: Option[List[Pod.HostAlias]] = None,
+  hostPID: Option[Boolean] = None,
+  hostIPC: Option[Boolean] = None,
+  automountServiceAccountToken: Option[Boolean] = None,
+  priority: Option[Int] = None,
+  priorityClassName: Option[String] = None,
+  schedulerName: Option[String] = None,
+  subdomain: Option[String] = None,
+  dnsConfig: Option[Pod.DNSConfig] = None,
+  shareProcessNamespace: Option[Boolean] = None
+) {
+  def addContainer(c: ContainerApplyConfig): PodSpecApplyConfig = copy(containers = Some(c :: containers.getOrElse(Nil)))
+  def addInitContainer(c: ContainerApplyConfig): PodSpecApplyConfig = copy(initContainers = Some(c :: initContainers.getOrElse(Nil)))
+  def addVolume(v: Volume): PodSpecApplyConfig = copy(volumes = Some(v :: volumes.getOrElse(Nil)))
+  def addNodeSelector(kv: (String, String)): PodSpecApplyConfig = copy(nodeSelector = Some(nodeSelector.getOrElse(Map.empty) + kv))
+  def addImagePullSecretRef(ref: String): PodSpecApplyConfig = copy(imagePullSecrets = Some(LocalObjectReference(ref) :: imagePullSecrets.getOrElse(Nil)))
+  def withTerminationGracePeriodSeconds(gp: Int): PodSpecApplyConfig = copy(terminationGracePeriodSeconds = Some(gp))
+  def withActiveDeadlineSeconds(ad: Int): PodSpecApplyConfig = copy(activeDeadlineSeconds = Some(ad))
+  def withDnsPolicy(dp: DNSPolicy.DNSPolicy): PodSpecApplyConfig = copy(dnsPolicy = Some(dp))
+  def withNodeName(nn: String): PodSpecApplyConfig = copy(nodeName = Some(nn))
+  def withServiceAccountName(san: String): PodSpecApplyConfig = copy(serviceAccountName = Some(san))
+  def withRestartPolicy(rp: RestartPolicy.RestartPolicy): PodSpecApplyConfig = copy(restartPolicy = Some(rp))
+  def useHostNetwork: PodSpecApplyConfig = copy(hostNetwork = Some(true))
+}
+
+object PodSpecApplyConfig {
+
+  implicit val writes: OWrites[PodSpecApplyConfig] = {
+    val partOne = (
+      (JsPath \ "containers").writeNullable[List[ContainerApplyConfig]] and
+      (JsPath \ "initContainers").writeNullable[List[ContainerApplyConfig]] and
+      (JsPath \ "volumes").writeNullable[List[Volume]] and
+      (JsPath \ "restartPolicy").writeNullable[String] and
+      (JsPath \ "terminationGracePeriodSeconds").writeNullable[Int] and
+      (JsPath \ "activeDeadlineSeconds").writeNullable[Int] and
+      (JsPath \ "dnsPolicy").writeNullable[String] and
+      (JsPath \ "nodeSelector").writeNullable[Map[String, String]] and
+      (JsPath \ "serviceAccountName").writeNullable[String] and
+      (JsPath \ "nodeName").writeNullable[String] and
+      (JsPath \ "hostNetwork").writeNullable[Boolean] and
+      (JsPath \ "imagePullSecrets").writeNullable[List[LocalObjectReference]] and
+      (JsPath \ "affinity").writeNullable[Pod.Affinity] and
+      (JsPath \ "tolerations").writeNullable[List[Pod.Toleration]] and
+      (JsPath \ "topologySpreadConstraints").writeNullable[List[Pod.TopologySpreadConstraints]] and
+      (JsPath \ "securityContext").writeNullable[PodSecurityContext]
+    ).tupled
+
+    val partTwo = (
+      (JsPath \ "hostname").writeNullable[String] and
+      (JsPath \ "hostAliases").writeNullable[List[Pod.HostAlias]] and
+      (JsPath \ "hostPID").writeNullable[Boolean] and
+      (JsPath \ "hostIPC").writeNullable[Boolean] and
+      (JsPath \ "automountServiceAccountToken").writeNullable[Boolean] and
+      (JsPath \ "priority").writeNullable[Int] and
+      (JsPath \ "priorityClassName").writeNullable[String] and
+      (JsPath \ "schedulerName").writeNullable[String] and
+      (JsPath \ "subdomain").writeNullable[String] and
+      (JsPath \ "dnsConfig").writeNullable[Pod.DNSConfig] and
+      (JsPath \ "shareProcessNamespace").writeNullable[Boolean]
+    ).tupled
+
+    OWrites[PodSpecApplyConfig] { s =>
+      val p1 = partOne.writes((s.containers, s.initContainers, s.volumes, s.restartPolicy.map(_.toString), s.terminationGracePeriodSeconds, s.activeDeadlineSeconds, s.dnsPolicy.map(_.toString), s.nodeSelector, s.serviceAccountName, s.nodeName, s.hostNetwork, s.imagePullSecrets, s.affinity, s.tolerations, s.topologySpreadConstraints, s.securityContext))
+      val p2 = partTwo.writes((s.hostname, s.hostAliases, s.hostPID, s.hostIPC, s.automountServiceAccountToken, s.priority, s.priorityClassName, s.schedulerName, s.subdomain, s.dnsConfig, s.shareProcessNamespace))
+      p1.deepMerge(p2)
+    }
+  }
+}
+
+case class PodApplyConfig(
+  kind: String = "Pod",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[PodSpecApplyConfig] = None
+) extends ApplyConfiguration[Pod] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): PodApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): PodApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): PodApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: PodSpecApplyConfig): PodApplyConfig = copy(spec = Some(s))
+}
+
+object PodApplyConfig {
+  def apply(name: String): PodApplyConfig =
+    PodApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  def apply(name: String, spec: PodSpecApplyConfig): PodApplyConfig =
+    PodApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))), spec = Some(spec))
+
+  implicit val writes: OWrites[PodApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[PodSpecApplyConfig]
+  )(p => (p.kind, p.apiVersion, p.metadata, p.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/PodTemplateSpecApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/PodTemplateSpecApplyConfig.scala
@@ -1,0 +1,37 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+
+case class PodTemplateSpecApplyConfig(
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[PodSpecApplyConfig] = None
+) {
+  def addLabel(kv: (String, String)): PodTemplateSpecApplyConfig =
+    copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addLabels(labels: Map[String, String]): PodTemplateSpecApplyConfig =
+    copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).withLabels(
+      metadata.flatMap(_.labels).getOrElse(Map.empty) ++ labels
+    )))
+  def addAnnotation(kv: (String, String)): PodTemplateSpecApplyConfig =
+    copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def addContainer(c: ContainerApplyConfig): PodTemplateSpecApplyConfig =
+    copy(spec = Some(spec.getOrElse(PodSpecApplyConfig()).addContainer(c)))
+  def addInitContainer(c: ContainerApplyConfig): PodTemplateSpecApplyConfig =
+    copy(spec = Some(spec.getOrElse(PodSpecApplyConfig()).addInitContainer(c)))
+  def addVolume(v: Volume): PodTemplateSpecApplyConfig =
+    copy(spec = Some(spec.getOrElse(PodSpecApplyConfig()).addVolume(v)))
+  def withServiceAccountName(san: String): PodTemplateSpecApplyConfig =
+    copy(spec = Some(spec.getOrElse(PodSpecApplyConfig()).withServiceAccountName(san)))
+  def withRestartPolicy(rp: RestartPolicy.RestartPolicy): PodTemplateSpecApplyConfig =
+    copy(spec = Some(spec.getOrElse(PodSpecApplyConfig()).withRestartPolicy(rp)))
+  def withPodSpec(s: PodSpecApplyConfig): PodTemplateSpecApplyConfig = copy(spec = Some(s))
+}
+
+object PodTemplateSpecApplyConfig {
+  implicit val writes: OWrites[PodTemplateSpecApplyConfig] = (
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[PodSpecApplyConfig]
+  )(t => (t.metadata, t.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/ReplicationControllerApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/ReplicationControllerApplyConfig.scala
@@ -1,0 +1,49 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+
+case class ReplicationControllerSpecApplyConfig(
+  replicas: Option[Int] = None,
+  selector: Option[Map[String, String]] = None,
+  template: Option[PodTemplateSpecApplyConfig] = None
+) {
+  def withReplicas(n: Int): ReplicationControllerSpecApplyConfig = copy(replicas = Some(n))
+  def withSelector(s: Map[String, String]): ReplicationControllerSpecApplyConfig = copy(selector = Some(s))
+  def withTemplate(t: PodTemplateSpecApplyConfig): ReplicationControllerSpecApplyConfig = copy(template = Some(t))
+}
+
+object ReplicationControllerSpecApplyConfig {
+  implicit val writes: OWrites[ReplicationControllerSpecApplyConfig] = (
+    (JsPath \ "replicas").writeNullable[Int] and
+    (JsPath \ "selector").writeNullable[Map[String, String]] and
+    (JsPath \ "template").writeNullable[PodTemplateSpecApplyConfig]
+  )(s => (s.replicas, s.selector, s.template))
+}
+
+case class ReplicationControllerApplyConfig(
+  kind: String = "ReplicationController",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[ReplicationControllerSpecApplyConfig] = None
+) extends ApplyConfiguration[ReplicationController] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): ReplicationControllerApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): ReplicationControllerApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): ReplicationControllerApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: ReplicationControllerSpecApplyConfig): ReplicationControllerApplyConfig = copy(spec = Some(s))
+  def withReplicas(n: Int): ReplicationControllerApplyConfig = copy(spec = Some(spec.getOrElse(ReplicationControllerSpecApplyConfig()).withReplicas(n)))
+}
+
+object ReplicationControllerApplyConfig {
+  def apply(name: String): ReplicationControllerApplyConfig =
+    ReplicationControllerApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ReplicationControllerApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[ReplicationControllerSpecApplyConfig]
+  )(r => (r.kind, r.apiVersion, r.metadata, r.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/ResourceQuotaApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/ResourceQuotaApplyConfig.scala
@@ -1,0 +1,44 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class ResourceQuotaSpecApplyConfig(
+  hard: Option[Resource.ResourceList] = None
+) {
+  def withHard(h: Resource.ResourceList): ResourceQuotaSpecApplyConfig = copy(hard = Some(h))
+  def addHard(kv: (String, Resource.Quantity)): ResourceQuotaSpecApplyConfig =
+    copy(hard = Some(hard.getOrElse(Map.empty) + kv))
+}
+
+object ResourceQuotaSpecApplyConfig {
+  implicit val writes: OWrites[ResourceQuotaSpecApplyConfig] =
+    (JsPath \ "hard").writeNullable[Resource.ResourceList].contramap(_.hard)
+}
+
+case class ResourceQuotaApplyConfig(
+  kind: String = "ResourceQuota",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[ResourceQuotaSpecApplyConfig] = None
+) extends ApplyConfiguration[Resource.Quota] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): ResourceQuotaApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): ResourceQuotaApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): ResourceQuotaApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: ResourceQuotaSpecApplyConfig): ResourceQuotaApplyConfig = copy(spec = Some(s))
+}
+
+object ResourceQuotaApplyConfig {
+  def apply(name: String): ResourceQuotaApplyConfig =
+    ResourceQuotaApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ResourceQuotaApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[ResourceQuotaSpecApplyConfig]
+  )(r => (r.kind, r.apiVersion, r.metadata, r.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/SecretApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/SecretApplyConfig.scala
@@ -1,0 +1,38 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format.mapStringByteArrayFormat
+
+case class SecretApplyConfig(
+  kind: String = "Secret",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  data: Option[Map[String, Array[Byte]]] = None,
+  stringData: Option[Map[String, String]] = None,
+  `type`: Option[String] = None
+) extends ApplyConfiguration[Secret] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): SecretApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): SecretApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): SecretApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withData(d: Map[String, Array[Byte]]): SecretApplyConfig = copy(data = Some(d))
+  def addData(kv: (String, Array[Byte])): SecretApplyConfig = copy(data = Some(data.getOrElse(Map.empty) + kv))
+  def withStringData(d: Map[String, String]): SecretApplyConfig = copy(stringData = Some(d))
+  def withType(t: String): SecretApplyConfig = copy(`type` = Some(t))
+}
+
+object SecretApplyConfig {
+  def apply(name: String): SecretApplyConfig =
+    SecretApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[SecretApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "data").writeNullable[Map[String, Array[Byte]]] and
+    (JsPath \ "stringData").writeNullable[Map[String, String]] and
+    (JsPath \ "type").writeNullable[String]
+  )(s => (s.kind, s.apiVersion, s.metadata, s.data, s.stringData, s.`type`))
+}

--- a/core/src/main/scala/skuber/model/ac/ServiceAccountApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/ServiceAccountApplyConfig.scala
@@ -1,0 +1,34 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class ServiceAccountApplyConfig(
+  kind: String = "ServiceAccount",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  secrets: Option[List[ObjectReference]] = None,
+  imagePullSecrets: Option[List[LocalObjectReference]] = None
+) extends ApplyConfiguration[ServiceAccount] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): ServiceAccountApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): ServiceAccountApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): ServiceAccountApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def addImagePullSecret(name: String): ServiceAccountApplyConfig =
+    copy(imagePullSecrets = Some(LocalObjectReference(name) :: imagePullSecrets.getOrElse(Nil)))
+}
+
+object ServiceAccountApplyConfig {
+  def apply(name: String): ServiceAccountApplyConfig =
+    ServiceAccountApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ServiceAccountApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "secrets").writeNullable[List[ObjectReference]] and
+    (JsPath \ "imagePullSecrets").writeNullable[List[LocalObjectReference]]
+  )(s => (s.kind, s.apiVersion, s.metadata, s.secrets, s.imagePullSecrets))
+}

--- a/core/src/main/scala/skuber/model/ac/ServiceApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/ServiceApplyConfig.scala
@@ -1,0 +1,68 @@
+package skuber.model.ac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.json.format._
+
+case class ServiceSpecApplyConfig(
+  ports: Option[List[Service.Port]] = None,
+  selector: Option[Map[String, String]] = None,
+  clusterIP: Option[String] = None,
+  _type: Option[Service.Type.Value] = None,
+  externalIPs: Option[List[String]] = None,
+  sessionAffinity: Option[Service.Affinity.Value] = None,
+  loadBalancerIP: Option[String] = None,
+  externalTrafficPolicy: Option[Service.ExternalTrafficPolicy.Value] = None
+) {
+  def withSelector(sel: Map[String, String]): ServiceSpecApplyConfig = copy(selector = Some(sel))
+  def setPort(p: Service.Port): ServiceSpecApplyConfig = copy(ports = Some(List(p)))
+  def setPorts(ps: List[Service.Port]): ServiceSpecApplyConfig = copy(ports = Some(ps))
+  def exposeOnPort(p: Service.Port): ServiceSpecApplyConfig = copy(ports = Some(p :: ports.getOrElse(Nil)))
+  def withType(t: Service.Type.Value): ServiceSpecApplyConfig = copy(_type = Some(t))
+  def withClusterIP(ip: String): ServiceSpecApplyConfig = copy(clusterIP = Some(ip))
+  def isHeadless: ServiceSpecApplyConfig = copy(clusterIP = Some("None"))
+  def withLoadBalancerIP(ip: String): ServiceSpecApplyConfig = copy(loadBalancerIP = Some(ip))
+  def withExternalTrafficPolicy(p: Service.ExternalTrafficPolicy.Value): ServiceSpecApplyConfig = copy(externalTrafficPolicy = Some(p))
+  def withSessionAffinity(a: Service.Affinity.Value): ServiceSpecApplyConfig = copy(sessionAffinity = Some(a))
+}
+
+object ServiceSpecApplyConfig {
+  implicit val writes: OWrites[ServiceSpecApplyConfig] = (
+    (JsPath \ "ports").writeNullable[List[Service.Port]] and
+    (JsPath \ "selector").writeNullable[Map[String, String]] and
+    (JsPath \ "clusterIP").writeNullable[String] and
+    (JsPath \ "type").writeNullable[String] and
+    (JsPath \ "externalIPs").writeNullable[List[String]] and
+    (JsPath \ "sessionAffinity").writeNullable[String] and
+    (JsPath \ "loadBalancerIP").writeNullable[String] and
+    (JsPath \ "externalTrafficPolicy").writeNullable[String]
+  )(s => (s.ports, s.selector, s.clusterIP, s._type.map(_.toString), s.externalIPs, s.sessionAffinity.map(_.toString), s.loadBalancerIP, s.externalTrafficPolicy.map(_.toString)))
+}
+
+case class ServiceApplyConfig(
+  kind: String = "Service",
+  apiVersion: String = "v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[ServiceSpecApplyConfig] = None
+) extends ApplyConfiguration[Service] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): ServiceApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): ServiceApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): ServiceApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: ServiceSpecApplyConfig): ServiceApplyConfig = copy(spec = Some(s))
+  def withSelector(sel: Map[String, String]): ServiceApplyConfig = copy(spec = Some(spec.getOrElse(ServiceSpecApplyConfig()).withSelector(sel)))
+  def setPort(p: Service.Port): ServiceApplyConfig = copy(spec = Some(spec.getOrElse(ServiceSpecApplyConfig()).setPort(p)))
+}
+
+object ServiceApplyConfig {
+  def apply(name: String): ServiceApplyConfig =
+    ServiceApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ServiceApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[ServiceSpecApplyConfig]
+  )(s => (s.kind, s.apiVersion, s.metadata, s.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/apps/v1/DaemonSetApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/apps/v1/DaemonSetApplyConfig.scala
@@ -1,0 +1,57 @@
+package skuber.model.ac.apps.v1
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.DaemonSet
+import skuber.json.format._
+
+case class DaemonSetSpecApplyConfig(
+  selector: Option[LabelSelector] = None,
+  template: Option[PodTemplateSpecApplyConfig] = None,
+  minReadySeconds: Option[Int] = None,
+  updateStrategy: Option[DaemonSet.UpdateStrategy] = None,
+  revisionHistoryLimit: Option[Int] = None
+) {
+  def withSelector(s: LabelSelector): DaemonSetSpecApplyConfig = copy(selector = Some(s))
+  def withTemplate(t: PodTemplateSpecApplyConfig): DaemonSetSpecApplyConfig = copy(template = Some(t))
+  def withMinReadySeconds(s: Int): DaemonSetSpecApplyConfig = copy(minReadySeconds = Some(s))
+  def withUpdateStrategy(s: DaemonSet.UpdateStrategy): DaemonSetSpecApplyConfig = copy(updateStrategy = Some(s))
+  def withRevisionHistoryLimit(l: Int): DaemonSetSpecApplyConfig = copy(revisionHistoryLimit = Some(l))
+}
+
+object DaemonSetSpecApplyConfig {
+  implicit val writes: OWrites[DaemonSetSpecApplyConfig] = (
+    (JsPath \ "selector").writeNullable[LabelSelector] and
+    (JsPath \ "template").writeNullable[PodTemplateSpecApplyConfig] and
+    (JsPath \ "minReadySeconds").writeNullable[Int] and
+    (JsPath \ "updateStrategy").writeNullable[DaemonSet.UpdateStrategy] and
+    (JsPath \ "revisionHistoryLimit").writeNullable[Int]
+  )(d => (d.selector, d.template, d.minReadySeconds, d.updateStrategy, d.revisionHistoryLimit))
+}
+
+case class DaemonSetApplyConfig(
+  kind: String = "DaemonSet",
+  apiVersion: String = "apps/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[DaemonSetSpecApplyConfig] = None
+) extends ApplyConfiguration[DaemonSet] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): DaemonSetApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): DaemonSetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): DaemonSetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: DaemonSetSpecApplyConfig): DaemonSetApplyConfig = copy(spec = Some(s))
+}
+
+object DaemonSetApplyConfig {
+  def apply(name: String): DaemonSetApplyConfig =
+    DaemonSetApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[DaemonSetApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[DaemonSetSpecApplyConfig]
+  )(d => (d.kind, d.apiVersion, d.metadata, d.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/apps/v1/DeploymentApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/apps/v1/DeploymentApplyConfig.scala
@@ -1,0 +1,67 @@
+package skuber.model.ac.apps.v1
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.Deployment
+import skuber.json.format._
+
+case class DeploymentSpecApplyConfig(
+  replicas: Option[Int] = None,
+  selector: Option[LabelSelector] = None,
+  template: Option[PodTemplateSpecApplyConfig] = None,
+  strategy: Option[Deployment.Strategy] = None,
+  minReadySeconds: Option[Int] = None,
+  revisionHistoryLimit: Option[Int] = None,
+  paused: Option[Boolean] = None,
+  progressDeadlineSeconds: Option[Int] = None
+) {
+  def withReplicas(n: Int): DeploymentSpecApplyConfig = copy(replicas = Some(n))
+  def withSelector(s: LabelSelector): DeploymentSpecApplyConfig = copy(selector = Some(s))
+  def withTemplate(t: PodTemplateSpecApplyConfig): DeploymentSpecApplyConfig = copy(template = Some(t))
+  def withStrategy(s: Deployment.Strategy): DeploymentSpecApplyConfig = copy(strategy = Some(s))
+  def withMinReadySeconds(s: Int): DeploymentSpecApplyConfig = copy(minReadySeconds = Some(s))
+  def withRevisionHistoryLimit(l: Int): DeploymentSpecApplyConfig = copy(revisionHistoryLimit = Some(l))
+  def withPaused(p: Boolean): DeploymentSpecApplyConfig = copy(paused = Some(p))
+  def withProgressDeadlineSeconds(s: Int): DeploymentSpecApplyConfig = copy(progressDeadlineSeconds = Some(s))
+}
+
+object DeploymentSpecApplyConfig {
+  implicit val writes: OWrites[DeploymentSpecApplyConfig] = (
+    (JsPath \ "replicas").writeNullable[Int] and
+    (JsPath \ "selector").writeNullable[LabelSelector] and
+    (JsPath \ "template").writeNullable[PodTemplateSpecApplyConfig] and
+    (JsPath \ "strategy").writeNullable[Deployment.Strategy] and
+    (JsPath \ "minReadySeconds").writeNullable[Int] and
+    (JsPath \ "revisionHistoryLimit").writeNullable[Int] and
+    (JsPath \ "paused").writeNullable[Boolean] and
+    (JsPath \ "progressDeadlineSeconds").writeNullable[Int]
+  )(d => (d.replicas, d.selector, d.template, d.strategy, d.minReadySeconds, d.revisionHistoryLimit, d.paused, d.progressDeadlineSeconds))
+}
+
+case class DeploymentApplyConfig(
+  kind: String = "Deployment",
+  apiVersion: String = "apps/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[DeploymentSpecApplyConfig] = None
+) extends ApplyConfiguration[Deployment] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): DeploymentApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): DeploymentApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): DeploymentApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: DeploymentSpecApplyConfig): DeploymentApplyConfig = copy(spec = Some(s))
+  def withReplicas(count: Int): DeploymentApplyConfig = copy(spec = Some(spec.getOrElse(DeploymentSpecApplyConfig()).copy(replicas = Some(count))))
+}
+
+object DeploymentApplyConfig {
+  def apply(name: String): DeploymentApplyConfig =
+    DeploymentApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[DeploymentApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[DeploymentSpecApplyConfig]
+  )(d => (d.kind, d.apiVersion, d.metadata, d.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/apps/v1/ReplicaSetApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/apps/v1/ReplicaSetApplyConfig.scala
@@ -1,0 +1,55 @@
+package skuber.model.ac.apps.v1
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.ReplicaSet
+import skuber.json.format._
+
+case class ReplicaSetSpecApplyConfig(
+  replicas: Option[Int] = None,
+  minReadySeconds: Option[Int] = None,
+  selector: Option[LabelSelector] = None,
+  template: Option[PodTemplateSpecApplyConfig] = None
+) {
+  def withReplicas(n: Int): ReplicaSetSpecApplyConfig = copy(replicas = Some(n))
+  def withMinReadySeconds(s: Int): ReplicaSetSpecApplyConfig = copy(minReadySeconds = Some(s))
+  def withSelector(s: LabelSelector): ReplicaSetSpecApplyConfig = copy(selector = Some(s))
+  def withTemplate(t: PodTemplateSpecApplyConfig): ReplicaSetSpecApplyConfig = copy(template = Some(t))
+}
+
+object ReplicaSetSpecApplyConfig {
+  implicit val writes: OWrites[ReplicaSetSpecApplyConfig] = (
+    (JsPath \ "replicas").writeNullable[Int] and
+    (JsPath \ "minReadySeconds").writeNullable[Int] and
+    (JsPath \ "selector").writeNullable[LabelSelector] and
+    (JsPath \ "template").writeNullable[PodTemplateSpecApplyConfig]
+  )(s => (s.replicas, s.minReadySeconds, s.selector, s.template))
+}
+
+case class ReplicaSetApplyConfig(
+  kind: String = "ReplicaSet",
+  apiVersion: String = "apps/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[ReplicaSetSpecApplyConfig] = None
+) extends ApplyConfiguration[ReplicaSet] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): ReplicaSetApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): ReplicaSetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): ReplicaSetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: ReplicaSetSpecApplyConfig): ReplicaSetApplyConfig = copy(spec = Some(s))
+  def withReplicas(n: Int): ReplicaSetApplyConfig = copy(spec = Some(spec.getOrElse(ReplicaSetSpecApplyConfig()).withReplicas(n)))
+}
+
+object ReplicaSetApplyConfig {
+  def apply(name: String): ReplicaSetApplyConfig =
+    ReplicaSetApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ReplicaSetApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[ReplicaSetSpecApplyConfig]
+  )(r => (r.kind, r.apiVersion, r.metadata, r.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/apps/v1/StatefulSetApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/apps/v1/StatefulSetApplyConfig.scala
@@ -1,0 +1,65 @@
+package skuber.model.ac.apps.v1
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.StatefulSet
+import skuber.json.format._
+
+case class StatefulSetSpecApplyConfig(
+  replicas: Option[Int] = None,
+  serviceName: Option[String] = None,
+  selector: Option[LabelSelector] = None,
+  template: Option[PodTemplateSpecApplyConfig] = None,
+  volumeClaimTemplates: Option[List[PersistentVolumeClaimApplyConfig]] = None,
+  updateStrategy: Option[StatefulSet.UpdateStrategy] = None,
+  revisionHistoryLimit: Option[Int] = None
+) {
+  def withReplicas(n: Int): StatefulSetSpecApplyConfig = copy(replicas = Some(n))
+  def withServiceName(sn: String): StatefulSetSpecApplyConfig = copy(serviceName = Some(sn))
+  def withSelector(s: LabelSelector): StatefulSetSpecApplyConfig = copy(selector = Some(s))
+  def withTemplate(t: PodTemplateSpecApplyConfig): StatefulSetSpecApplyConfig = copy(template = Some(t))
+  def addVolumeClaimTemplate(vct: PersistentVolumeClaimApplyConfig): StatefulSetSpecApplyConfig =
+    copy(volumeClaimTemplates = Some(vct :: volumeClaimTemplates.getOrElse(Nil)))
+  def withUpdateStrategy(s: StatefulSet.UpdateStrategy): StatefulSetSpecApplyConfig = copy(updateStrategy = Some(s))
+  def withRevisionHistoryLimit(l: Int): StatefulSetSpecApplyConfig = copy(revisionHistoryLimit = Some(l))
+}
+
+object StatefulSetSpecApplyConfig {
+  implicit val writes: OWrites[StatefulSetSpecApplyConfig] = (
+    (JsPath \ "replicas").writeNullable[Int] and
+    (JsPath \ "serviceName").writeNullable[String] and
+    (JsPath \ "selector").writeNullable[LabelSelector] and
+    (JsPath \ "template").writeNullable[PodTemplateSpecApplyConfig] and
+    (JsPath \ "volumeClaimTemplates").writeNullable[List[PersistentVolumeClaimApplyConfig]] and
+    (JsPath \ "updateStrategy").writeNullable[StatefulSet.UpdateStrategy] and
+    (JsPath \ "revisionHistoryLimit").writeNullable[Int]
+  )(s => (s.replicas, s.serviceName, s.selector, s.template, s.volumeClaimTemplates, s.updateStrategy, s.revisionHistoryLimit))
+}
+
+case class StatefulSetApplyConfig(
+  kind: String = "StatefulSet",
+  apiVersion: String = "apps/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[StatefulSetSpecApplyConfig] = None
+) extends ApplyConfiguration[StatefulSet] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): StatefulSetApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): StatefulSetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): StatefulSetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: StatefulSetSpecApplyConfig): StatefulSetApplyConfig = copy(spec = Some(s))
+  def withReplicas(n: Int): StatefulSetApplyConfig = copy(spec = Some(spec.getOrElse(StatefulSetSpecApplyConfig()).withReplicas(n)))
+}
+
+object StatefulSetApplyConfig {
+  def apply(name: String): StatefulSetApplyConfig =
+    StatefulSetApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[StatefulSetApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[StatefulSetSpecApplyConfig]
+  )(s => (s.kind, s.apiVersion, s.metadata, s.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/autoscaling/v2/HPAApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/autoscaling/v2/HPAApplyConfig.scala
@@ -1,0 +1,58 @@
+package skuber.model.ac.autoscaling.v2
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.autoscaling.v2.HorizontalPodAutoscaler
+import skuber.model.autoscaling.v2.HorizontalPodAutoscaler._
+
+case class HPASpecApplyConfig(
+  scaleTargetRef: Option[CrossVersionObjectReference] = None,
+  minReplicas: Option[Int] = None,
+  maxReplicas: Option[Int] = None,
+  metrics: Option[List[Metric]] = None,
+  behavior: Option[Spec.Behavior] = None
+) {
+  def withScaleTargetRef(ref: CrossVersionObjectReference): HPASpecApplyConfig = copy(scaleTargetRef = Some(ref))
+  def withMinReplicas(n: Int): HPASpecApplyConfig = copy(minReplicas = Some(n))
+  def withMaxReplicas(n: Int): HPASpecApplyConfig = copy(maxReplicas = Some(n))
+  def addMetric(m: Metric): HPASpecApplyConfig = copy(metrics = Some(metrics.getOrElse(Nil) :+ m))
+  def withMetrics(m: List[Metric]): HPASpecApplyConfig = copy(metrics = Some(m))
+  def withBehavior(b: Spec.Behavior): HPASpecApplyConfig = copy(behavior = Some(b))
+}
+
+object HPASpecApplyConfig {
+  implicit val writes: OWrites[HPASpecApplyConfig] = (
+    (JsPath \ "scaleTargetRef").writeNullable[CrossVersionObjectReference] and
+    (JsPath \ "minReplicas").writeNullable[Int] and
+    (JsPath \ "maxReplicas").writeNullable[Int] and
+    (JsPath \ "metrics").writeNullable[List[Metric]] and
+    (JsPath \ "behavior").writeNullable[Spec.Behavior]
+  )(s => (s.scaleTargetRef, s.minReplicas, s.maxReplicas, s.metrics, s.behavior))
+}
+
+case class HPAApplyConfig(
+  kind: String = "HorizontalPodAutoscaler",
+  apiVersion: String = "autoscaling/v2",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[HPASpecApplyConfig] = None
+) extends ApplyConfiguration[HorizontalPodAutoscaler] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): HPAApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): HPAApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): HPAApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: HPASpecApplyConfig): HPAApplyConfig = copy(spec = Some(s))
+}
+
+object HPAApplyConfig {
+  def apply(name: String): HPAApplyConfig =
+    HPAApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[HPAApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[HPASpecApplyConfig]
+  )(h => (h.kind, h.apiVersion, h.metadata, h.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/batch/CronJobApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/batch/CronJobApplyConfig.scala
@@ -1,0 +1,77 @@
+package skuber.model.ac.batch
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.batch.CronJob
+
+case class JobTemplateSpecApplyConfig(
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[JobSpecApplyConfig] = None
+) {
+  def withMetadata(m: ObjectMetaApplyConfig): JobTemplateSpecApplyConfig = copy(metadata = Some(m))
+  def withSpec(s: JobSpecApplyConfig): JobTemplateSpecApplyConfig = copy(spec = Some(s))
+}
+
+object JobTemplateSpecApplyConfig {
+  implicit val writes: OWrites[JobTemplateSpecApplyConfig] = (
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[JobSpecApplyConfig]
+  )(t => (t.metadata, t.spec))
+}
+
+case class CronJobSpecApplyConfig(
+  schedule: Option[String] = None,
+  jobTemplate: Option[JobTemplateSpecApplyConfig] = None,
+  startingDeadlineSeconds: Option[Long] = None,
+  concurrencyPolicy: Option[String] = None,
+  suspend: Option[Boolean] = None,
+  successfulJobsHistoryLimit: Option[Int] = None,
+  failedJobsHistoryLimit: Option[Int] = None
+) {
+  def withSchedule(s: String): CronJobSpecApplyConfig = copy(schedule = Some(s))
+  def withJobTemplate(t: JobTemplateSpecApplyConfig): CronJobSpecApplyConfig = copy(jobTemplate = Some(t))
+  def withStartingDeadlineSeconds(s: Long): CronJobSpecApplyConfig = copy(startingDeadlineSeconds = Some(s))
+  def withConcurrencyPolicy(p: String): CronJobSpecApplyConfig = copy(concurrencyPolicy = Some(p))
+  def withSuspend(s: Boolean): CronJobSpecApplyConfig = copy(suspend = Some(s))
+  def withSuccessfulJobsHistoryLimit(l: Int): CronJobSpecApplyConfig = copy(successfulJobsHistoryLimit = Some(l))
+  def withFailedJobsHistoryLimit(l: Int): CronJobSpecApplyConfig = copy(failedJobsHistoryLimit = Some(l))
+}
+
+object CronJobSpecApplyConfig {
+  implicit val writes: OWrites[CronJobSpecApplyConfig] = (
+    (JsPath \ "schedule").writeNullable[String] and
+    (JsPath \ "jobTemplate").writeNullable[JobTemplateSpecApplyConfig] and
+    (JsPath \ "startingDeadlineSeconds").writeNullable[Long] and
+    (JsPath \ "concurrencyPolicy").writeNullable[String] and
+    (JsPath \ "suspend").writeNullable[Boolean] and
+    (JsPath \ "successfulJobsHistoryLimit").writeNullable[Int] and
+    (JsPath \ "failedJobsHistoryLimit").writeNullable[Int]
+  )(s => (s.schedule, s.jobTemplate, s.startingDeadlineSeconds, s.concurrencyPolicy, s.suspend, s.successfulJobsHistoryLimit, s.failedJobsHistoryLimit))
+}
+
+case class CronJobApplyConfig(
+  kind: String = "CronJob",
+  apiVersion: String = "batch/v1beta1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[CronJobSpecApplyConfig] = None
+) extends ApplyConfiguration[CronJob] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): CronJobApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): CronJobApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): CronJobApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: CronJobSpecApplyConfig): CronJobApplyConfig = copy(spec = Some(s))
+}
+
+object CronJobApplyConfig {
+  def apply(name: String): CronJobApplyConfig =
+    CronJobApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[CronJobApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[CronJobSpecApplyConfig]
+  )(c => (c.kind, c.apiVersion, c.metadata, c.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/batch/JobApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/batch/JobApplyConfig.scala
@@ -1,0 +1,65 @@
+package skuber.model.ac.batch
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.batch.Job
+import skuber.json.format._
+
+case class JobSpecApplyConfig(
+  parallelism: Option[Int] = None,
+  completions: Option[Int] = None,
+  activeDeadlineSeconds: Option[Long] = None,
+  selector: Option[LabelSelector] = None,
+  manualSelector: Option[Boolean] = None,
+  template: Option[PodTemplateSpecApplyConfig] = None,
+  backoffLimit: Option[Int] = None,
+  ttlSecondsAfterFinished: Option[Int] = None
+) {
+  def withParallelism(n: Int): JobSpecApplyConfig = copy(parallelism = Some(n))
+  def withCompletions(n: Int): JobSpecApplyConfig = copy(completions = Some(n))
+  def withActiveDeadlineSeconds(s: Long): JobSpecApplyConfig = copy(activeDeadlineSeconds = Some(s))
+  def withSelector(s: LabelSelector): JobSpecApplyConfig = copy(selector = Some(s))
+  def withTemplate(t: PodTemplateSpecApplyConfig): JobSpecApplyConfig = copy(template = Some(t))
+  def withBackoffLimit(n: Int): JobSpecApplyConfig = copy(backoffLimit = Some(n))
+  def withTTLSecondsAfterFinished(n: Int): JobSpecApplyConfig = copy(ttlSecondsAfterFinished = Some(n))
+}
+
+object JobSpecApplyConfig {
+  implicit val writes: OWrites[JobSpecApplyConfig] = (
+    (JsPath \ "parallelism").writeNullable[Int] and
+    (JsPath \ "completions").writeNullable[Int] and
+    (JsPath \ "activeDeadlineSeconds").writeNullable[Long] and
+    (JsPath \ "selector").writeNullable[LabelSelector] and
+    (JsPath \ "manualSelector").writeNullable[Boolean] and
+    (JsPath \ "template").writeNullable[PodTemplateSpecApplyConfig] and
+    (JsPath \ "backoffLimit").writeNullable[Int] and
+    (JsPath \ "ttlSecondsAfterFinished").writeNullable[Int]
+  )(s => (s.parallelism, s.completions, s.activeDeadlineSeconds, s.selector, s.manualSelector, s.template, s.backoffLimit, s.ttlSecondsAfterFinished))
+}
+
+case class JobApplyConfig(
+  kind: String = "Job",
+  apiVersion: String = "batch/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[JobSpecApplyConfig] = None
+) extends ApplyConfiguration[Job] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): JobApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): JobApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): JobApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: JobSpecApplyConfig): JobApplyConfig = copy(spec = Some(s))
+}
+
+object JobApplyConfig {
+  def apply(name: String): JobApplyConfig =
+    JobApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[JobApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[JobSpecApplyConfig]
+  )(j => (j.kind, j.apiVersion, j.metadata, j.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/networking/IngressApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/networking/IngressApplyConfig.scala
@@ -1,0 +1,56 @@
+package skuber.model.ac.networking
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.networking.Ingress
+import skuber.json.format._
+import skuber.json.networking.format._
+
+case class IngressSpecApplyConfig(
+  defaultBackend: Option[Ingress.Backend] = None,
+  ingressClassName: Option[String] = None,
+  rules: Option[List[Ingress.Rule]] = None,
+  tls: Option[List[Ingress.TLS]] = None
+) {
+  def withDefaultBackend(b: Ingress.Backend): IngressSpecApplyConfig = copy(defaultBackend = Some(b))
+  def withIngressClassName(cn: String): IngressSpecApplyConfig = copy(ingressClassName = Some(cn))
+  def addRule(r: Ingress.Rule): IngressSpecApplyConfig = copy(rules = Some(rules.getOrElse(Nil) :+ r))
+  def withRules(r: List[Ingress.Rule]): IngressSpecApplyConfig = copy(rules = Some(r))
+  def addTLS(t: Ingress.TLS): IngressSpecApplyConfig = copy(tls = Some(t :: tls.getOrElse(Nil)))
+}
+
+object IngressSpecApplyConfig {
+  implicit val writes: OWrites[IngressSpecApplyConfig] = (
+    (JsPath \ "defaultBackend").writeNullable[Ingress.Backend] and
+    (JsPath \ "ingressClassName").writeNullable[String] and
+    (JsPath \ "rules").writeNullable[List[Ingress.Rule]] and
+    (JsPath \ "tls").writeNullable[List[Ingress.TLS]]
+  )(s => (s.defaultBackend, s.ingressClassName, s.rules, s.tls))
+}
+
+case class IngressApplyConfig(
+  kind: String = "Ingress",
+  apiVersion: String = "networking.k8s.io/v1beta1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[IngressSpecApplyConfig] = None
+) extends ApplyConfiguration[Ingress] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): IngressApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): IngressApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): IngressApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: IngressSpecApplyConfig): IngressApplyConfig = copy(spec = Some(s))
+}
+
+object IngressApplyConfig {
+  def apply(name: String): IngressApplyConfig =
+    IngressApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[IngressApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[IngressSpecApplyConfig]
+  )(i => (i.kind, i.apiVersion, i.metadata, i.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/networking/NetworkPolicyApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/networking/NetworkPolicyApplyConfig.scala
@@ -1,0 +1,56 @@
+package skuber.model.ac.networking
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.networking.NetworkPolicy
+import skuber.json.format._
+
+case class NetworkPolicySpecApplyConfig(
+  podSelector: Option[LabelSelector] = None,
+  ingress: Option[List[NetworkPolicy.IngressRule]] = None,
+  egress: Option[List[NetworkPolicy.EgressRule]] = None,
+  policyTypes: Option[List[String]] = None
+) {
+  def withPodSelector(s: LabelSelector): NetworkPolicySpecApplyConfig = copy(podSelector = Some(s))
+  def addIngressRule(r: NetworkPolicy.IngressRule): NetworkPolicySpecApplyConfig =
+    copy(ingress = Some(r :: ingress.getOrElse(Nil)))
+  def addEgressRule(r: NetworkPolicy.EgressRule): NetworkPolicySpecApplyConfig =
+    copy(egress = Some(r :: egress.getOrElse(Nil)))
+  def withPolicyTypes(t: List[String]): NetworkPolicySpecApplyConfig = copy(policyTypes = Some(t))
+}
+
+object NetworkPolicySpecApplyConfig {
+  implicit val writes: OWrites[NetworkPolicySpecApplyConfig] = (
+    (JsPath \ "podSelector").writeNullable[LabelSelector] and
+    (JsPath \ "ingress").writeNullable[List[NetworkPolicy.IngressRule]] and
+    (JsPath \ "egress").writeNullable[List[NetworkPolicy.EgressRule]] and
+    (JsPath \ "policyTypes").writeNullable[List[String]]
+  )(s => (s.podSelector, s.ingress, s.egress, s.policyTypes))
+}
+
+case class NetworkPolicyApplyConfig(
+  kind: String = "NetworkPolicy",
+  apiVersion: String = "networking.k8s.io/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[NetworkPolicySpecApplyConfig] = None
+) extends ApplyConfiguration[NetworkPolicy] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): NetworkPolicyApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): NetworkPolicyApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): NetworkPolicyApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: NetworkPolicySpecApplyConfig): NetworkPolicyApplyConfig = copy(spec = Some(s))
+}
+
+object NetworkPolicyApplyConfig {
+  def apply(name: String): NetworkPolicyApplyConfig =
+    NetworkPolicyApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[NetworkPolicyApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[NetworkPolicySpecApplyConfig]
+  )(n => (n.kind, n.apiVersion, n.metadata, n.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/package.scala
+++ b/core/src/main/scala/skuber/model/ac/package.scala
@@ -1,0 +1,36 @@
+package skuber.model
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+package object ac {
+
+  trait ApplyConfiguration[O <: ObjectResource] {
+    def name: String
+  }
+
+  case class ObjectMetaApplyConfig(
+    name: Option[String] = None,
+    namespace: Option[String] = None,
+    labels: Option[Map[String, String]] = None,
+    annotations: Option[Map[String, String]] = None,
+    finalizers: Option[List[String]] = None
+  ) {
+    def withName(n: String): ObjectMetaApplyConfig = copy(name = Some(n))
+    def withNamespace(ns: String): ObjectMetaApplyConfig = copy(namespace = Some(ns))
+    def withLabels(l: Map[String, String]): ObjectMetaApplyConfig = copy(labels = Some(l))
+    def addLabel(kv: (String, String)): ObjectMetaApplyConfig = copy(labels = Some(labels.getOrElse(Map.empty) + kv))
+    def withAnnotations(a: Map[String, String]): ObjectMetaApplyConfig = copy(annotations = Some(a))
+    def addAnnotation(kv: (String, String)): ObjectMetaApplyConfig = copy(annotations = Some(annotations.getOrElse(Map.empty) + kv))
+  }
+
+  object ObjectMetaApplyConfig {
+    implicit val writes: OWrites[ObjectMetaApplyConfig] = (
+      (JsPath \ "name").writeNullable[String] and
+      (JsPath \ "namespace").writeNullable[String] and
+      (JsPath \ "labels").writeNullable[Map[String, String]] and
+      (JsPath \ "annotations").writeNullable[Map[String, String]] and
+      (JsPath \ "finalizers").writeNullable[List[String]]
+    )(o => (o.name, o.namespace, o.labels, o.annotations, o.finalizers))
+  }
+}

--- a/core/src/main/scala/skuber/model/ac/policy/v1/PodDisruptionBudgetApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/policy/v1/PodDisruptionBudgetApplyConfig.scala
@@ -1,0 +1,52 @@
+package skuber.model.ac.policy.v1
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.policy.v1.PodDisruptionBudget
+import skuber.json.format._
+
+case class PodDisruptionBudgetSpecApplyConfig(
+  maxUnavailable: Option[IntOrString] = None,
+  minAvailable: Option[IntOrString] = None,
+  selector: Option[LabelSelector] = None
+) {
+  def withMaxUnavailable(v: IntOrString): PodDisruptionBudgetSpecApplyConfig = copy(maxUnavailable = Some(v))
+  def withMinAvailable(v: IntOrString): PodDisruptionBudgetSpecApplyConfig = copy(minAvailable = Some(v))
+  def withSelector(s: LabelSelector): PodDisruptionBudgetSpecApplyConfig = copy(selector = Some(s))
+}
+
+object PodDisruptionBudgetSpecApplyConfig {
+  implicit val writes: OWrites[PodDisruptionBudgetSpecApplyConfig] = OWrites { s =>
+    Json.obj() ++
+      s.maxUnavailable.fold(Json.obj())(v => Json.obj("maxUnavailable" -> v)) ++
+      s.minAvailable.fold(Json.obj())(v => Json.obj("minAvailable" -> v)) ++
+      s.selector.fold(Json.obj())(v => Json.obj("selector" -> Json.toJson(v)))
+  }
+}
+
+case class PodDisruptionBudgetApplyConfig(
+  kind: String = "PodDisruptionBudget",
+  apiVersion: String = "policy/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  spec: Option[PodDisruptionBudgetSpecApplyConfig] = None
+) extends ApplyConfiguration[PodDisruptionBudget] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): PodDisruptionBudgetApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): PodDisruptionBudgetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): PodDisruptionBudgetApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withSpec(s: PodDisruptionBudgetSpecApplyConfig): PodDisruptionBudgetApplyConfig = copy(spec = Some(s))
+}
+
+object PodDisruptionBudgetApplyConfig {
+  def apply(name: String): PodDisruptionBudgetApplyConfig =
+    PodDisruptionBudgetApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[PodDisruptionBudgetApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "spec").writeNullable[PodDisruptionBudgetSpecApplyConfig]
+  )(p => (p.kind, p.apiVersion, p.metadata, p.spec))
+}

--- a/core/src/main/scala/skuber/model/ac/rbac/ClusterRoleApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/rbac/ClusterRoleApplyConfig.scala
@@ -1,0 +1,35 @@
+package skuber.model.ac.rbac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+case class ClusterRoleApplyConfig(
+  kind: String = "ClusterRole",
+  apiVersion: String = "rbac.authorization.k8s.io/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  rules: Option[List[PolicyRule]] = None
+) extends ApplyConfiguration[ClusterRole] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): ClusterRoleApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): ClusterRoleApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): ClusterRoleApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def addRule(rule: PolicyRule): ClusterRoleApplyConfig = copy(rules = Some(rule :: rules.getOrElse(Nil)))
+  def withRules(r: List[PolicyRule]): ClusterRoleApplyConfig = copy(rules = Some(r))
+}
+
+object ClusterRoleApplyConfig {
+  def apply(name: String): ClusterRoleApplyConfig =
+    ClusterRoleApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ClusterRoleApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "rules").writeNullable[List[PolicyRule]]
+  )(r => (r.kind, r.apiVersion, r.metadata, r.rules))
+}

--- a/core/src/main/scala/skuber/model/ac/rbac/ClusterRoleBindingApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/rbac/ClusterRoleBindingApplyConfig.scala
@@ -1,0 +1,38 @@
+package skuber.model.ac.rbac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+case class ClusterRoleBindingApplyConfig(
+  kind: String = "ClusterRoleBinding",
+  apiVersion: String = "rbac.authorization.k8s.io/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  roleRef: Option[RoleRef] = None,
+  subjects: Option[List[Subject]] = None
+) extends ApplyConfiguration[ClusterRoleBinding] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): ClusterRoleBindingApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): ClusterRoleBindingApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): ClusterRoleBindingApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withRoleRef(ref: RoleRef): ClusterRoleBindingApplyConfig = copy(roleRef = Some(ref))
+  def addSubject(s: Subject): ClusterRoleBindingApplyConfig = copy(subjects = Some(s :: subjects.getOrElse(Nil)))
+  def withSubjects(s: List[Subject]): ClusterRoleBindingApplyConfig = copy(subjects = Some(s))
+}
+
+object ClusterRoleBindingApplyConfig {
+  def apply(name: String): ClusterRoleBindingApplyConfig =
+    ClusterRoleBindingApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[ClusterRoleBindingApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "roleRef").writeNullable[RoleRef] and
+    (JsPath \ "subjects").writeNullable[List[Subject]]
+  )(r => (r.kind, r.apiVersion, r.metadata, r.roleRef, r.subjects))
+}

--- a/core/src/main/scala/skuber/model/ac/rbac/RoleApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/rbac/RoleApplyConfig.scala
@@ -1,0 +1,35 @@
+package skuber.model.ac.rbac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+case class RoleApplyConfig(
+  kind: String = "Role",
+  apiVersion: String = "rbac.authorization.k8s.io/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  rules: Option[List[PolicyRule]] = None
+) extends ApplyConfiguration[Role] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): RoleApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): RoleApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): RoleApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def addRule(rule: PolicyRule): RoleApplyConfig = copy(rules = Some(rule :: rules.getOrElse(Nil)))
+  def withRules(r: List[PolicyRule]): RoleApplyConfig = copy(rules = Some(r))
+}
+
+object RoleApplyConfig {
+  def apply(name: String): RoleApplyConfig =
+    RoleApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[RoleApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "rules").writeNullable[List[PolicyRule]]
+  )(r => (r.kind, r.apiVersion, r.metadata, r.rules))
+}

--- a/core/src/main/scala/skuber/model/ac/rbac/RoleBindingApplyConfig.scala
+++ b/core/src/main/scala/skuber/model/ac/rbac/RoleBindingApplyConfig.scala
@@ -1,0 +1,38 @@
+package skuber.model.ac.rbac
+
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+case class RoleBindingApplyConfig(
+  kind: String = "RoleBinding",
+  apiVersion: String = "rbac.authorization.k8s.io/v1",
+  metadata: Option[ObjectMetaApplyConfig] = None,
+  roleRef: Option[RoleRef] = None,
+  subjects: Option[List[Subject]] = None
+) extends ApplyConfiguration[RoleBinding] {
+  def name: String = metadata.flatMap(_.name).getOrElse("")
+  def withMetadata(m: ObjectMetaApplyConfig): RoleBindingApplyConfig = copy(metadata = Some(m))
+  def addLabel(kv: (String, String)): RoleBindingApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addLabel(kv)))
+  def addAnnotation(kv: (String, String)): RoleBindingApplyConfig = copy(metadata = Some(metadata.getOrElse(ObjectMetaApplyConfig()).addAnnotation(kv)))
+  def withRoleRef(ref: RoleRef): RoleBindingApplyConfig = copy(roleRef = Some(ref))
+  def addSubject(s: Subject): RoleBindingApplyConfig = copy(subjects = Some(s :: subjects.getOrElse(Nil)))
+  def withSubjects(s: List[Subject]): RoleBindingApplyConfig = copy(subjects = Some(s))
+}
+
+object RoleBindingApplyConfig {
+  def apply(name: String): RoleBindingApplyConfig =
+    RoleBindingApplyConfig(metadata = Some(ObjectMetaApplyConfig(name = Some(name))))
+
+  implicit val writes: OWrites[RoleBindingApplyConfig] = (
+    (JsPath \ "kind").write[String] and
+    (JsPath \ "apiVersion").write[String] and
+    (JsPath \ "metadata").writeNullable[ObjectMetaApplyConfig] and
+    (JsPath \ "roleRef").writeNullable[RoleRef] and
+    (JsPath \ "subjects").writeNullable[List[Subject]]
+  )(r => (r.kind, r.apiVersion, r.metadata, r.roleRef, r.subjects))
+}

--- a/core/src/test/scala/skuber/model/ac/ConfigMapApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/ConfigMapApplyConfigSpec.scala
@@ -1,0 +1,45 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+
+class ConfigMapApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ConfigMapApplyConfig" should "be constructed by name" in {
+    val cm = ConfigMapApplyConfig("my-config")
+    cm.name shouldBe "my-config"
+    cm.kind shouldBe "ConfigMap"
+    cm.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with kind, apiVersion, and only set fields" in {
+    val cm = ConfigMapApplyConfig("my-config")
+      .withData(Map("key1" -> "value1"))
+    val json = Json.toJson(cm)
+    (json \ "kind").as[String] shouldBe "ConfigMap"
+    (json \ "apiVersion").as[String] shouldBe "v1"
+    (json \ "metadata" \ "name").as[String] shouldBe "my-config"
+    (json \ "data" \ "key1").as[String] shouldBe "value1"
+    (json \ "binaryData").toOption shouldBe None
+  }
+
+  it should "omit data when not set" in {
+    val cm = ConfigMapApplyConfig("my-config")
+    val json = Json.toJson(cm)
+    (json \ "data").toOption shouldBe None
+  }
+
+  it should "support addData" in {
+    val cm = ConfigMapApplyConfig("my-config")
+      .addData("k1" -> "v1")
+      .addData("k2" -> "v2")
+    cm.data shouldBe Some(Map("k1" -> "v1", "k2" -> "v2"))
+  }
+
+  it should "extend ApplyConfiguration[ConfigMap]" in {
+    val cm: ApplyConfiguration[ConfigMap] = ConfigMapApplyConfig("my-config")
+    cm.name shouldBe "my-config"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/ContainerApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/ContainerApplyConfigSpec.scala
@@ -1,0 +1,81 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class ContainerApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ContainerApplyConfig" should "serialize only set fields" in {
+    val container = ContainerApplyConfig(name = Some("nginx"), image = Some("nginx:1.25"))
+    val json = Json.toJson(container)
+    (json \ "name").as[String] shouldBe "nginx"
+    (json \ "image").as[String] shouldBe "nginx:1.25"
+    (json \ "ports").toOption shouldBe None
+    (json \ "env").toOption shouldBe None
+    (json \ "command").toOption shouldBe None
+    (json \ "resources").toOption shouldBe None
+  }
+
+  it should "serialize ports when set" in {
+    val container = ContainerApplyConfig("nginx", "nginx:1.25").exposePort(80)
+    val json = Json.toJson(container)
+    (json \ "ports")(0).as[Container.Port].containerPort shouldBe 80
+  }
+
+  it should "serialize env vars when set" in {
+    val container = ContainerApplyConfig("nginx", "nginx:1.25").setEnvVar("HOME", "/root")
+    val json = Json.toJson(container)
+    (json \ "env")(0).as[EnvVar].name shouldBe "HOME"
+  }
+
+  it should "serialize resource limits when set" in {
+    val container = ContainerApplyConfig("nginx", "nginx:1.25")
+      .limitCPU("500m")
+      .limitMemory("128Mi")
+    val json = Json.toJson(container)
+    (json \ "resources" \ "limits" \ "cpu").as[String] shouldBe "500m"
+    (json \ "resources" \ "limits" \ "memory").as[String] shouldBe "128Mi"
+  }
+
+  "ContainerApplyConfig convenience constructor" should "set name and image" in {
+    val c = ContainerApplyConfig("test", "image:latest")
+    c.name shouldBe Some("test")
+    c.image shouldBe Some("image:latest")
+  }
+
+  "ContainerApplyConfig fluent API" should "support exposePort with Port" in {
+    val c = ContainerApplyConfig("test", "image:latest")
+      .exposePort(Container.Port(containerPort = 8080, name = "http"))
+    c.ports.get.head.containerPort shouldBe 8080
+    c.ports.get.head.name shouldBe "http"
+  }
+
+  it should "support mount" in {
+    val c = ContainerApplyConfig("test", "image:latest").mount("data", "/data", readOnly = true)
+    c.volumeMounts.get.head.name shouldBe "data"
+    c.volumeMounts.get.head.mountPath shouldBe "/data"
+    c.volumeMounts.get.head.readOnly shouldBe true
+  }
+
+  it should "support withArgs and withEntrypoint" in {
+    val c = ContainerApplyConfig("test", "image:latest").withEntrypoint("/bin/sh", "-c").withArgs("echo hello")
+    c.command shouldBe Some(List("/bin/sh", "-c"))
+    c.args shouldBe Some(List("echo hello"))
+  }
+
+  it should "support withImagePullPolicy" in {
+    val c = ContainerApplyConfig("test", "image:latest").withImagePullPolicy(Container.PullPolicy.Always)
+    c.imagePullPolicy shouldBe Some(Container.PullPolicy.Always)
+  }
+
+  it should "support resource requests" in {
+    val c = ContainerApplyConfig("test", "image:latest")
+      .requestCPU("250m")
+      .requestMemory("64Mi")
+    c.resources.get.requests("cpu").value shouldBe "250m"
+    c.resources.get.requests("memory").value shouldBe "64Mi"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/EndpointsApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/EndpointsApplyConfigSpec.scala
@@ -1,0 +1,40 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class EndpointsApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "EndpointsApplyConfig" should "be constructed by name" in {
+    val ep = EndpointsApplyConfig("my-endpoints")
+    ep.name shouldBe "my-endpoints"
+    ep.kind shouldBe "Endpoints"
+    ep.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with subsets" in {
+    val ep = EndpointsApplyConfig("my-endpoints")
+      .addSubset(Endpoints.Subset(
+        addresses = List(Endpoints.Address("10.0.0.1")),
+        notReadyAddresses = None,
+        ports = List(Endpoints.Port(8080))
+      ))
+    val json = Json.toJson(ep)
+    (json \ "kind").as[String] shouldBe "Endpoints"
+    (json \ "subsets").as[List[play.api.libs.json.JsValue]].size shouldBe 1
+  }
+
+  it should "omit subsets when not set" in {
+    val ep = EndpointsApplyConfig("my-endpoints")
+    val json = Json.toJson(ep)
+    (json \ "subsets").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[Endpoints]" in {
+    val ep: ApplyConfiguration[Endpoints] = EndpointsApplyConfig("my-endpoints")
+    ep.name shouldBe "my-endpoints"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/LimitRangeApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/LimitRangeApplyConfigSpec.scala
@@ -1,0 +1,36 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class LimitRangeApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "LimitRangeApplyConfig" should "be constructed by name" in {
+    val lr = LimitRangeApplyConfig("my-limits")
+    lr.name shouldBe "my-limits"
+    lr.kind shouldBe "LimitRange"
+    lr.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with items" in {
+    val lr = LimitRangeApplyConfig("my-limits")
+      .withSpec(LimitRangeSpecApplyConfig()
+        .addItem(LimitRange.Item(
+          _type = Some(LimitRange.ItemType.Container),
+          default = Map(Resource.memory -> Resource.Quantity("256Mi")),
+          defaultRequest = Map(Resource.memory -> Resource.Quantity("128Mi"))
+        ))
+      )
+    val json = Json.toJson(lr)
+    (json \ "kind").as[String] shouldBe "LimitRange"
+    (json \ "spec" \ "limits").as[List[play.api.libs.json.JsValue]].size shouldBe 1
+  }
+
+  it should "extend ApplyConfiguration[LimitRange]" in {
+    val lr: ApplyConfiguration[LimitRange] = LimitRangeApplyConfig("my-limits")
+    lr.name shouldBe "my-limits"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/NamespaceApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/NamespaceApplyConfigSpec.scala
@@ -1,0 +1,31 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+
+class NamespaceApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "NamespaceApplyConfig" should "be constructed by name" in {
+    val ns = NamespaceApplyConfig("my-namespace")
+    ns.name shouldBe "my-namespace"
+    ns.kind shouldBe "Namespace"
+    ns.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with kind, apiVersion, and metadata" in {
+    val ns = NamespaceApplyConfig("my-namespace")
+      .addLabel("env" -> "production")
+    val json = Json.toJson(ns)
+    (json \ "kind").as[String] shouldBe "Namespace"
+    (json \ "apiVersion").as[String] shouldBe "v1"
+    (json \ "metadata" \ "name").as[String] shouldBe "my-namespace"
+    (json \ "metadata" \ "labels" \ "env").as[String] shouldBe "production"
+  }
+
+  it should "extend ApplyConfiguration[Namespace]" in {
+    val ns: ApplyConfiguration[Namespace] = NamespaceApplyConfig("my-namespace")
+    ns.name shouldBe "my-namespace"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/ObjectMetaApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/ObjectMetaApplyConfigSpec.scala
@@ -1,0 +1,56 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+
+class ObjectMetaApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ObjectMetaApplyConfig" should "serialize only set fields, omitting None values" in {
+    val meta = ObjectMetaApplyConfig(name = Some("test-pod"))
+    val json = Json.toJson(meta)(ObjectMetaApplyConfig.writes)
+    (json \ "name").as[String] shouldBe "test-pod"
+    (json \ "namespace").toOption shouldBe None
+    (json \ "labels").toOption shouldBe None
+    (json \ "annotations").toOption shouldBe None
+    (json \ "finalizers").toOption shouldBe None
+  }
+
+  it should "serialize all set fields" in {
+    val meta = ObjectMetaApplyConfig(
+      name = Some("test"),
+      namespace = Some("default"),
+      labels = Some(Map("app" -> "web")),
+      annotations = Some(Map("note" -> "test")),
+      finalizers = Some(List("finalizer.example.com"))
+    )
+    val json = Json.toJson(meta)(ObjectMetaApplyConfig.writes)
+    (json \ "name").as[String] shouldBe "test"
+    (json \ "namespace").as[String] shouldBe "default"
+    (json \ "labels" \ "app").as[String] shouldBe "web"
+    (json \ "annotations" \ "note").as[String] shouldBe "test"
+    (json \ "finalizers")(0).as[String] shouldBe "finalizer.example.com"
+  }
+
+  it should "serialize an empty ObjectMetaApplyConfig as an empty JSON object" in {
+    val meta = ObjectMetaApplyConfig()
+    val json = Json.toJson(meta)(ObjectMetaApplyConfig.writes)
+    json shouldBe Json.obj()
+  }
+
+  "ObjectMetaApplyConfig fluent API" should "support addLabel" in {
+    val meta = ObjectMetaApplyConfig().addLabel("app" -> "web").addLabel("env" -> "prod")
+    meta.labels shouldBe Some(Map("app" -> "web", "env" -> "prod"))
+  }
+
+  it should "support addAnnotation" in {
+    val meta = ObjectMetaApplyConfig().addAnnotation("note" -> "test")
+    meta.annotations shouldBe Some(Map("note" -> "test"))
+  }
+
+  it should "support withName and withNamespace" in {
+    val meta = ObjectMetaApplyConfig().withName("test").withNamespace("default")
+    meta.name shouldBe Some("test")
+    meta.namespace shouldBe Some("default")
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/PersistentVolumeClaimApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/PersistentVolumeClaimApplyConfigSpec.scala
@@ -1,0 +1,42 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class PersistentVolumeClaimApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "PersistentVolumeClaimApplyConfig" should "be constructed by name" in {
+    val pvc = PersistentVolumeClaimApplyConfig("my-pvc")
+    pvc.name shouldBe "my-pvc"
+    pvc.kind shouldBe "PersistentVolumeClaim"
+    pvc.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val pvc = PersistentVolumeClaimApplyConfig("my-pvc")
+      .withSpec(PersistentVolumeClaimSpecApplyConfig()
+        .withAccessModes(List(PersistentVolume.AccessMode.ReadWriteOnce))
+        .withStorageClassName("standard")
+        .withStorageRequest("10Gi")
+      )
+    val json = Json.toJson(pvc)
+    (json \ "kind").as[String] shouldBe "PersistentVolumeClaim"
+    (json \ "spec" \ "accessModes")(0).as[String] shouldBe "ReadWriteOnce"
+    (json \ "spec" \ "storageClassName").as[String] shouldBe "standard"
+    (json \ "spec" \ "resources" \ "requests" \ "storage").as[String] shouldBe "10Gi"
+  }
+
+  it should "omit spec when not set" in {
+    val pvc = PersistentVolumeClaimApplyConfig("my-pvc")
+    val json = Json.toJson(pvc)
+    (json \ "spec").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[PersistentVolumeClaim]" in {
+    val pvc: ApplyConfiguration[PersistentVolumeClaim] = PersistentVolumeClaimApplyConfig("my-pvc")
+    pvc.name shouldBe "my-pvc"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/PodApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/PodApplyConfigSpec.scala
@@ -1,0 +1,68 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class PodApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "PodSpecApplyConfig" should "serialize only set fields" in {
+    val spec = PodSpecApplyConfig()
+      .addContainer(ContainerApplyConfig("nginx", "nginx:1.25"))
+      .withServiceAccountName("my-sa")
+    val json = Json.toJson(spec)
+    (json \ "containers").as[List[play.api.libs.json.JsValue]].size shouldBe 1
+    (json \ "serviceAccountName").as[String] shouldBe "my-sa"
+    (json \ "volumes").toOption shouldBe None
+    (json \ "restartPolicy").toOption shouldBe None
+    (json \ "nodeSelector").toOption shouldBe None
+  }
+
+  it should "support addVolume and addNodeSelector" in {
+    val spec = PodSpecApplyConfig()
+      .addVolume(Volume("data", Volume.EmptyDir()))
+      .addNodeSelector("disktype" -> "ssd")
+    spec.volumes.get.head.name shouldBe "data"
+    spec.nodeSelector.get("disktype") shouldBe "ssd"
+  }
+
+  it should "support withRestartPolicy" in {
+    val spec = PodSpecApplyConfig().withRestartPolicy(RestartPolicy.Never)
+    spec.restartPolicy shouldBe Some(RestartPolicy.Never)
+  }
+
+  "PodApplyConfig" should "be constructed by name" in {
+    val pod = PodApplyConfig("my-pod")
+    pod.name shouldBe "my-pod"
+    pod.kind shouldBe "Pod"
+    pod.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with kind, apiVersion, and only set fields" in {
+    val pod = PodApplyConfig("my-pod")
+      .addLabel("app" -> "web")
+      .withSpec(PodSpecApplyConfig()
+        .addContainer(ContainerApplyConfig("nginx", "nginx:1.25").exposePort(80))
+      )
+    val json = Json.toJson(pod)
+    (json \ "kind").as[String] shouldBe "Pod"
+    (json \ "apiVersion").as[String] shouldBe "v1"
+    (json \ "metadata" \ "name").as[String] shouldBe "my-pod"
+    (json \ "metadata" \ "labels" \ "app").as[String] shouldBe "web"
+    (json \ "spec" \ "containers")(0).as[play.api.libs.json.JsValue].\("name").as[String] shouldBe "nginx"
+    (json \ "spec" \ "containers")(0).as[play.api.libs.json.JsValue].\("ports")(0).\("containerPort").as[Int] shouldBe 80
+  }
+
+  it should "extend ApplyConfiguration[Pod]" in {
+    val pod: ApplyConfiguration[Pod] = PodApplyConfig("my-pod")
+    pod.name shouldBe "my-pod"
+  }
+
+  it should "serialize empty spec fields as absent" in {
+    val pod = PodApplyConfig("my-pod")
+    val json = Json.toJson(pod)
+    (json \ "spec").toOption shouldBe None
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/PodTemplateSpecApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/PodTemplateSpecApplyConfigSpec.scala
@@ -1,0 +1,38 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class PodTemplateSpecApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "PodTemplateSpecApplyConfig" should "serialize only set fields" in {
+    val tmpl = PodTemplateSpecApplyConfig()
+      .addLabel("app" -> "web")
+      .addContainer(ContainerApplyConfig("nginx", "nginx:1.25"))
+    val json = Json.toJson(tmpl)
+    (json \ "metadata" \ "labels" \ "app").as[String] shouldBe "web"
+    (json \ "spec" \ "containers")(0).as[play.api.libs.json.JsValue].\("name").as[String] shouldBe "nginx"
+  }
+
+  it should "serialize as empty object when nothing is set" in {
+    val tmpl = PodTemplateSpecApplyConfig()
+    val json = Json.toJson(tmpl)
+    (json \ "metadata").toOption shouldBe None
+    (json \ "spec").toOption shouldBe None
+  }
+
+  it should "delegate fluent methods to nested types" in {
+    val tmpl = PodTemplateSpecApplyConfig()
+      .addAnnotation("note" -> "test")
+      .addVolume(Volume("data", Volume.EmptyDir()))
+      .withServiceAccountName("my-sa")
+      .withRestartPolicy(RestartPolicy.OnFailure)
+    tmpl.metadata.get.annotations shouldBe Some(Map("note" -> "test"))
+    tmpl.spec.get.volumes.get.head.name shouldBe "data"
+    tmpl.spec.get.serviceAccountName shouldBe Some("my-sa")
+    tmpl.spec.get.restartPolicy shouldBe Some(RestartPolicy.OnFailure)
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/ReplicationControllerApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/ReplicationControllerApplyConfigSpec.scala
@@ -1,0 +1,38 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class ReplicationControllerApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ReplicationControllerApplyConfig" should "be constructed by name" in {
+    val rc = ReplicationControllerApplyConfig("my-rc")
+    rc.name shouldBe "my-rc"
+    rc.kind shouldBe "ReplicationController"
+    rc.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val rc = ReplicationControllerApplyConfig("my-rc")
+      .withSpec(ReplicationControllerSpecApplyConfig()
+        .withReplicas(3)
+        .withSelector(Map("app" -> "web"))
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addLabel("app" -> "web")
+          .addContainer(ContainerApplyConfig("nginx", "nginx:1.25"))
+        )
+      )
+    val json = Json.toJson(rc)
+    (json \ "kind").as[String] shouldBe "ReplicationController"
+    (json \ "spec" \ "replicas").as[Int] shouldBe 3
+    (json \ "spec" \ "selector" \ "app").as[String] shouldBe "web"
+  }
+
+  it should "extend ApplyConfiguration[ReplicationController]" in {
+    val rc: ApplyConfiguration[ReplicationController] = ReplicationControllerApplyConfig("my-rc")
+    rc.name shouldBe "my-rc"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/ResourceQuotaApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/ResourceQuotaApplyConfigSpec.scala
@@ -1,0 +1,39 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class ResourceQuotaApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ResourceQuotaApplyConfig" should "be constructed by name" in {
+    val rq = ResourceQuotaApplyConfig("my-quota")
+    rq.name shouldBe "my-quota"
+    rq.kind shouldBe "ResourceQuota"
+    rq.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with hard limits" in {
+    val rq = ResourceQuotaApplyConfig("my-quota")
+      .withSpec(ResourceQuotaSpecApplyConfig()
+        .withHard(Map(Resource.pods -> Resource.Quantity("10"), Resource.cpu -> Resource.Quantity("4")))
+      )
+    val json = Json.toJson(rq)
+    (json \ "kind").as[String] shouldBe "ResourceQuota"
+    (json \ "spec" \ "hard" \ "pods").as[String] shouldBe "10"
+    (json \ "spec" \ "hard" \ "cpu").as[String] shouldBe "4"
+  }
+
+  it should "omit spec when not set" in {
+    val rq = ResourceQuotaApplyConfig("my-quota")
+    val json = Json.toJson(rq)
+    (json \ "spec").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[Resource.Quota]" in {
+    val rq: ApplyConfiguration[Resource.Quota] = ResourceQuotaApplyConfig("my-quota")
+    rq.name shouldBe "my-quota"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/SecretApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/SecretApplyConfigSpec.scala
@@ -1,0 +1,53 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class SecretApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "SecretApplyConfig" should "be constructed by name" in {
+    val secret = SecretApplyConfig("my-secret")
+    secret.name shouldBe "my-secret"
+    secret.kind shouldBe "Secret"
+    secret.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with kind, apiVersion, and only set fields" in {
+    val secret = SecretApplyConfig("my-secret")
+      .withData(Map("password" -> "cGFzc3dvcmQ=".getBytes))
+      .withType("Opaque")
+    val json = Json.toJson(secret)
+    (json \ "kind").as[String] shouldBe "Secret"
+    (json \ "apiVersion").as[String] shouldBe "v1"
+    (json \ "metadata" \ "name").as[String] shouldBe "my-secret"
+    (json \ "type").as[String] shouldBe "Opaque"
+  }
+
+  it should "omit data and type when not set" in {
+    val secret = SecretApplyConfig("my-secret")
+    val json = Json.toJson(secret)
+    (json \ "data").toOption shouldBe None
+    (json \ "type").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[Secret]" in {
+    val secret: ApplyConfiguration[Secret] = SecretApplyConfig("my-secret")
+    secret.name shouldBe "my-secret"
+  }
+
+  it should "support addData" in {
+    val secret = SecretApplyConfig("my-secret")
+      .addData("key1" -> "val1".getBytes)
+      .addData("key2" -> "val2".getBytes)
+    secret.data.get.size shouldBe 2
+  }
+
+  it should "support withStringData" in {
+    val secret = SecretApplyConfig("my-secret")
+      .withStringData(Map("config.yaml" -> "key: value"))
+    secret.stringData shouldBe Some(Map("config.yaml" -> "key: value"))
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/ServiceAccountApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/ServiceAccountApplyConfigSpec.scala
@@ -1,0 +1,39 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class ServiceAccountApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ServiceAccountApplyConfig" should "be constructed by name" in {
+    val sa = ServiceAccountApplyConfig("my-sa")
+    sa.name shouldBe "my-sa"
+    sa.kind shouldBe "ServiceAccount"
+    sa.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with kind, apiVersion, and only set fields" in {
+    val sa = ServiceAccountApplyConfig("my-sa")
+      .addImagePullSecret("my-registry-key")
+    val json = Json.toJson(sa)
+    (json \ "kind").as[String] shouldBe "ServiceAccount"
+    (json \ "apiVersion").as[String] shouldBe "v1"
+    (json \ "metadata" \ "name").as[String] shouldBe "my-sa"
+    (json \ "imagePullSecrets")(0).as[LocalObjectReference].name shouldBe "my-registry-key"
+  }
+
+  it should "omit secrets and imagePullSecrets when not set" in {
+    val sa = ServiceAccountApplyConfig("my-sa")
+    val json = Json.toJson(sa)
+    (json \ "secrets").toOption shouldBe None
+    (json \ "imagePullSecrets").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[ServiceAccount]" in {
+    val sa: ApplyConfiguration[ServiceAccount] = ServiceAccountApplyConfig("my-sa")
+    sa.name shouldBe "my-sa"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/ServiceApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/ServiceApplyConfigSpec.scala
@@ -1,0 +1,64 @@
+package skuber.model.ac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.json.format._
+
+class ServiceApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ServiceApplyConfig" should "be constructed by name" in {
+    val svc = ServiceApplyConfig("my-service")
+    svc.name shouldBe "my-service"
+    svc.kind shouldBe "Service"
+    svc.apiVersion shouldBe "v1"
+  }
+
+  it should "serialize with kind, apiVersion, and only set fields" in {
+    val svc = ServiceApplyConfig("my-service")
+      .withSelector(Map("app" -> "web"))
+      .setPort(Service.Port(port = 80))
+    val json = Json.toJson(svc)
+    (json \ "kind").as[String] shouldBe "Service"
+    (json \ "apiVersion").as[String] shouldBe "v1"
+    (json \ "metadata" \ "name").as[String] shouldBe "my-service"
+    (json \ "spec" \ "selector" \ "app").as[String] shouldBe "web"
+    (json \ "spec" \ "ports")(0).as[play.api.libs.json.JsValue].\("port").as[Int] shouldBe 80
+  }
+
+  it should "omit spec when not set" in {
+    val svc = ServiceApplyConfig("my-service")
+    val json = Json.toJson(svc)
+    (json \ "spec").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[Service]" in {
+    val svc: ApplyConfiguration[Service] = ServiceApplyConfig("my-service")
+    svc.name shouldBe "my-service"
+  }
+
+  "ServiceSpecApplyConfig" should "serialize only set fields" in {
+    val spec = ServiceSpecApplyConfig().withSelector(Map("app" -> "web"))
+    val json = Json.toJson(spec)(ServiceSpecApplyConfig.writes)
+    (json \ "selector" \ "app").as[String] shouldBe "web"
+    (json \ "ports").toOption shouldBe None
+    (json \ "clusterIP").toOption shouldBe None
+    (json \ "type").toOption shouldBe None
+  }
+
+  it should "support withType and isHeadless" in {
+    val spec = ServiceSpecApplyConfig().withType(Service.Type.LoadBalancer)
+    spec._type shouldBe Some(Service.Type.LoadBalancer)
+
+    val headless = ServiceSpecApplyConfig().isHeadless
+    headless.clusterIP shouldBe Some("None")
+  }
+
+  it should "support exposeOnPort" in {
+    val spec = ServiceSpecApplyConfig()
+      .exposeOnPort(Service.Port(port = 80))
+      .exposeOnPort(Service.Port(port = 443))
+    spec.ports.get.size shouldBe 2
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/apps/v1/DaemonSetApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/apps/v1/DaemonSetApplyConfigSpec.scala
@@ -1,0 +1,39 @@
+package skuber.model.ac.apps.v1
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.DaemonSet
+import skuber.json.format._
+
+class DaemonSetApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "DaemonSetApplyConfig" should "be constructed by name" in {
+    val ds = DaemonSetApplyConfig("my-daemonset")
+    ds.name shouldBe "my-daemonset"
+    ds.kind shouldBe "DaemonSet"
+    ds.apiVersion shouldBe "apps/v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val ds = DaemonSetApplyConfig("my-daemonset")
+      .withSpec(DaemonSetSpecApplyConfig()
+        .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", "monitoring")))
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addLabel("app" -> "monitoring")
+          .addContainer(ContainerApplyConfig("agent", "monitoring:latest"))
+        )
+      )
+    val json = Json.toJson(ds)
+    (json \ "kind").as[String] shouldBe "DaemonSet"
+    (json \ "apiVersion").as[String] shouldBe "apps/v1"
+    (json \ "spec" \ "template" \ "spec" \ "containers")(0).as[play.api.libs.json.JsValue].\("name").as[String] shouldBe "agent"
+  }
+
+  it should "extend ApplyConfiguration[DaemonSet]" in {
+    val ds: ApplyConfiguration[DaemonSet] = DaemonSetApplyConfig("my-daemonset")
+    ds.name shouldBe "my-daemonset"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/apps/v1/DeploymentApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/apps/v1/DeploymentApplyConfigSpec.scala
@@ -1,0 +1,83 @@
+package skuber.model.ac.apps.v1
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.Deployment
+import skuber.json.format._
+
+class DeploymentApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "DeploymentApplyConfig" should "be constructed by name" in {
+    val depl = DeploymentApplyConfig("nginx-deployment")
+    depl.name shouldBe "nginx-deployment"
+    depl.kind shouldBe "Deployment"
+    depl.apiVersion shouldBe "apps/v1"
+  }
+
+  it should "serialize the full Deployment example from the spec" in {
+    val depl = DeploymentApplyConfig("nginx-deployment")
+      .addLabel("app" -> "nginx")
+      .withSpec(DeploymentSpecApplyConfig()
+        .withReplicas(3)
+        .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", "nginx")))
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addLabel("app" -> "nginx")
+          .addContainer(ContainerApplyConfig("nginx", "nginx:1.25")
+            .exposePort(80)
+            .limitMemory("128Mi")
+            .limitCPU("500m")
+          )
+        )
+      )
+
+    val json = Json.toJson(depl)
+    (json \ "kind").as[String] shouldBe "Deployment"
+    (json \ "apiVersion").as[String] shouldBe "apps/v1"
+    (json \ "metadata" \ "name").as[String] shouldBe "nginx-deployment"
+    (json \ "metadata" \ "labels" \ "app").as[String] shouldBe "nginx"
+    (json \ "spec" \ "replicas").as[Int] shouldBe 3
+    (json \ "spec" \ "template" \ "metadata" \ "labels" \ "app").as[String] shouldBe "nginx"
+
+    val container = (json \ "spec" \ "template" \ "spec" \ "containers")(0)
+    (container \ "name").as[String] shouldBe "nginx"
+    (container \ "image").as[String] shouldBe "nginx:1.25"
+    (container \ "ports")(0).\("containerPort").as[Int] shouldBe 80
+    (container \ "resources" \ "limits" \ "memory").as[String] shouldBe "128Mi"
+    (container \ "resources" \ "limits" \ "cpu").as[String] shouldBe "500m"
+  }
+
+  it should "omit spec when not set" in {
+    val depl = DeploymentApplyConfig("test")
+    val json = Json.toJson(depl)
+    (json \ "spec").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[Deployment]" in {
+    val depl: ApplyConfiguration[Deployment] = DeploymentApplyConfig("test")
+    depl.name shouldBe "test"
+  }
+
+  it should "support withReplicas shortcut" in {
+    val depl = DeploymentApplyConfig("test").withReplicas(5)
+    depl.spec.get.replicas shouldBe Some(5)
+  }
+
+  "DeploymentSpecApplyConfig" should "serialize only set fields" in {
+    val spec = DeploymentSpecApplyConfig().withReplicas(3)
+    val json = Json.toJson(spec)(DeploymentSpecApplyConfig.writes)
+    (json \ "replicas").as[Int] shouldBe 3
+    (json \ "selector").toOption shouldBe None
+    (json \ "template").toOption shouldBe None
+    (json \ "strategy").toOption shouldBe None
+  }
+
+  it should "serialize strategy when set" in {
+    val spec = DeploymentSpecApplyConfig()
+      .withStrategy(Deployment.Strategy(Deployment.StrategyType.Recreate))
+    val json = Json.toJson(spec)(DeploymentSpecApplyConfig.writes)
+    (json \ "strategy" \ "type").as[String] shouldBe "Recreate"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/apps/v1/ReplicaSetApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/apps/v1/ReplicaSetApplyConfigSpec.scala
@@ -1,0 +1,40 @@
+package skuber.model.ac.apps.v1
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.ReplicaSet
+import skuber.json.format._
+
+class ReplicaSetApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ReplicaSetApplyConfig" should "be constructed by name" in {
+    val rs = ReplicaSetApplyConfig("my-rs")
+    rs.name shouldBe "my-rs"
+    rs.kind shouldBe "ReplicaSet"
+    rs.apiVersion shouldBe "apps/v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val rs = ReplicaSetApplyConfig("my-rs")
+      .withSpec(ReplicaSetSpecApplyConfig()
+        .withReplicas(3)
+        .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", "web")))
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addLabel("app" -> "web")
+          .addContainer(ContainerApplyConfig("nginx", "nginx:1.25"))
+        )
+      )
+    val json = Json.toJson(rs)
+    (json \ "kind").as[String] shouldBe "ReplicaSet"
+    (json \ "apiVersion").as[String] shouldBe "apps/v1"
+    (json \ "spec" \ "replicas").as[Int] shouldBe 3
+  }
+
+  it should "extend ApplyConfiguration[ReplicaSet]" in {
+    val rs: ApplyConfiguration[ReplicaSet] = ReplicaSetApplyConfig("my-rs")
+    rs.name shouldBe "my-rs"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/apps/v1/StatefulSetApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/apps/v1/StatefulSetApplyConfigSpec.scala
@@ -1,0 +1,59 @@
+package skuber.model.ac.apps.v1
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.apps.v1.StatefulSet
+import skuber.json.format._
+
+class StatefulSetApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "StatefulSetApplyConfig" should "be constructed by name" in {
+    val sts = StatefulSetApplyConfig("my-sts")
+    sts.name shouldBe "my-sts"
+    sts.kind shouldBe "StatefulSet"
+    sts.apiVersion shouldBe "apps/v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val sts = StatefulSetApplyConfig("my-sts")
+      .withSpec(StatefulSetSpecApplyConfig()
+        .withReplicas(3)
+        .withServiceName("my-service")
+        .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", "db")))
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addLabel("app" -> "db")
+          .addContainer(ContainerApplyConfig("postgres", "postgres:16"))
+        )
+      )
+    val json = Json.toJson(sts)
+    (json \ "kind").as[String] shouldBe "StatefulSet"
+    (json \ "apiVersion").as[String] shouldBe "apps/v1"
+    (json \ "spec" \ "replicas").as[Int] shouldBe 3
+    (json \ "spec" \ "serviceName").as[String] shouldBe "my-service"
+  }
+
+  it should "omit spec when not set" in {
+    val sts = StatefulSetApplyConfig("my-sts")
+    val json = Json.toJson(sts)
+    (json \ "spec").toOption shouldBe None
+  }
+
+  it should "extend ApplyConfiguration[StatefulSet]" in {
+    val sts: ApplyConfiguration[StatefulSet] = StatefulSetApplyConfig("my-sts")
+    sts.name shouldBe "my-sts"
+  }
+
+  it should "support volumeClaimTemplates" in {
+    val spec = StatefulSetSpecApplyConfig()
+      .addVolumeClaimTemplate(PersistentVolumeClaimApplyConfig("data")
+        .withSpec(PersistentVolumeClaimSpecApplyConfig()
+          .withAccessModes(List(PersistentVolume.AccessMode.ReadWriteOnce))
+          .withStorageRequest("10Gi")
+        )
+      )
+    spec.volumeClaimTemplates.get.size shouldBe 1
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/autoscaling/v2/HPAApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/autoscaling/v2/HPAApplyConfigSpec.scala
@@ -1,0 +1,48 @@
+package skuber.model.ac.autoscaling.v2
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.autoscaling.v2.HorizontalPodAutoscaler
+import skuber.json.format._
+
+class HPAApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "HPAApplyConfig" should "be constructed by name" in {
+    val hpa = HPAApplyConfig("my-hpa")
+    hpa.name shouldBe "my-hpa"
+    hpa.kind shouldBe "HorizontalPodAutoscaler"
+    hpa.apiVersion shouldBe "autoscaling/v2"
+  }
+
+  it should "serialize with spec fields" in {
+    val hpa = HPAApplyConfig("my-hpa")
+      .withSpec(HPASpecApplyConfig()
+        .withScaleTargetRef(HorizontalPodAutoscaler.CrossVersionObjectReference("apps/v1", "Deployment", "my-deployment"))
+        .withMinReplicas(2)
+        .withMaxReplicas(10)
+      )
+    val json = Json.toJson(hpa)
+    (json \ "kind").as[String] shouldBe "HorizontalPodAutoscaler"
+    (json \ "apiVersion").as[String] shouldBe "autoscaling/v2"
+    (json \ "spec" \ "minReplicas").as[Int] shouldBe 2
+    (json \ "spec" \ "maxReplicas").as[Int] shouldBe 10
+    (json \ "spec" \ "scaleTargetRef" \ "name").as[String] shouldBe "my-deployment"
+  }
+
+  it should "extend ApplyConfiguration[HorizontalPodAutoscaler]" in {
+    val hpa: ApplyConfiguration[HorizontalPodAutoscaler] = HPAApplyConfig("my-hpa")
+    hpa.name shouldBe "my-hpa"
+  }
+
+  it should "support adding metrics" in {
+    val spec = HPASpecApplyConfig()
+      .withScaleTargetRef(HorizontalPodAutoscaler.CrossVersionObjectReference("apps/v1", "Deployment", "my-dep"))
+      .addMetric(HorizontalPodAutoscaler.ResourceMetric(
+        HorizontalPodAutoscaler.ResourceMetricSource("cpu", HorizontalPodAutoscaler.UtilizationTarget(80))
+      ))
+    spec.metrics.get.size shouldBe 1
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/batch/CronJobApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/batch/CronJobApplyConfigSpec.scala
@@ -1,0 +1,54 @@
+package skuber.model.ac.batch
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.batch.CronJob
+import skuber.json.format._
+
+class CronJobApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "CronJobApplyConfig" should "be constructed by name" in {
+    val cj = CronJobApplyConfig("my-cronjob")
+    cj.name shouldBe "my-cronjob"
+    cj.kind shouldBe "CronJob"
+    cj.apiVersion shouldBe "batch/v1beta1"
+  }
+
+  it should "serialize with spec fields" in {
+    val cj = CronJobApplyConfig("my-cronjob")
+      .withSpec(CronJobSpecApplyConfig()
+        .withSchedule("*/5 * * * *")
+        .withJobTemplate(JobTemplateSpecApplyConfig()
+          .withSpec(JobSpecApplyConfig()
+            .withTemplate(PodTemplateSpecApplyConfig()
+              .addContainer(ContainerApplyConfig("worker", "worker:latest"))
+              .withRestartPolicy(RestartPolicy.Never)
+            )
+          )
+        )
+        .withConcurrencyPolicy("Forbid")
+      )
+    val json = Json.toJson(cj)
+    (json \ "kind").as[String] shouldBe "CronJob"
+    (json \ "spec" \ "schedule").as[String] shouldBe "*/5 * * * *"
+    (json \ "spec" \ "concurrencyPolicy").as[String] shouldBe "Forbid"
+  }
+
+  it should "extend ApplyConfiguration[CronJob]" in {
+    val cj: ApplyConfiguration[CronJob] = CronJobApplyConfig("my-cronjob")
+    cj.name shouldBe "my-cronjob"
+  }
+
+  it should "support suspend and history limits" in {
+    val spec = CronJobSpecApplyConfig()
+      .withSuspend(true)
+      .withSuccessfulJobsHistoryLimit(3)
+      .withFailedJobsHistoryLimit(1)
+    spec.suspend shouldBe Some(true)
+    spec.successfulJobsHistoryLimit shouldBe Some(3)
+    spec.failedJobsHistoryLimit shouldBe Some(1)
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/batch/JobApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/batch/JobApplyConfigSpec.scala
@@ -1,0 +1,48 @@
+package skuber.model.ac.batch
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.batch.Job
+import skuber.json.format._
+
+class JobApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "JobApplyConfig" should "be constructed by name" in {
+    val job = JobApplyConfig("my-job")
+    job.name shouldBe "my-job"
+    job.kind shouldBe "Job"
+    job.apiVersion shouldBe "batch/v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val job = JobApplyConfig("my-job")
+      .withSpec(JobSpecApplyConfig()
+        .withParallelism(2)
+        .withCompletions(5)
+        .withBackoffLimit(3)
+        .withTemplate(PodTemplateSpecApplyConfig()
+          .addContainer(ContainerApplyConfig("worker", "worker:latest"))
+          .withRestartPolicy(RestartPolicy.Never)
+        )
+      )
+    val json = Json.toJson(job)
+    (json \ "kind").as[String] shouldBe "Job"
+    (json \ "apiVersion").as[String] shouldBe "batch/v1"
+    (json \ "spec" \ "parallelism").as[Int] shouldBe 2
+    (json \ "spec" \ "completions").as[Int] shouldBe 5
+    (json \ "spec" \ "backoffLimit").as[Int] shouldBe 3
+  }
+
+  it should "extend ApplyConfiguration[Job]" in {
+    val job: ApplyConfiguration[Job] = JobApplyConfig("my-job")
+    job.name shouldBe "my-job"
+  }
+
+  it should "support ttlSecondsAfterFinished" in {
+    val spec = JobSpecApplyConfig().withTTLSecondsAfterFinished(300)
+    spec.ttlSecondsAfterFinished shouldBe Some(300)
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/networking/IngressApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/networking/IngressApplyConfigSpec.scala
@@ -1,0 +1,48 @@
+package skuber.model.ac.networking
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.networking.Ingress
+import skuber.json.format._
+import skuber.json.networking.format._
+
+class IngressApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "IngressApplyConfig" should "be constructed by name" in {
+    val ing = IngressApplyConfig("my-ingress")
+    ing.name shouldBe "my-ingress"
+    ing.kind shouldBe "Ingress"
+    ing.apiVersion shouldBe "networking.k8s.io/v1beta1"
+  }
+
+  it should "serialize with spec fields" in {
+    val ing = IngressApplyConfig("my-ingress")
+      .withSpec(IngressSpecApplyConfig()
+        .withIngressClassName("nginx")
+        .addRule(Ingress.Rule(
+          host = Some("example.com"),
+          http = Ingress.HttpRule(List(
+            Ingress.Path("/", None, Ingress.Backend("my-service", Left(80)))
+          ))
+        ))
+      )
+    val json = Json.toJson(ing)
+    (json \ "kind").as[String] shouldBe "Ingress"
+    (json \ "spec" \ "ingressClassName").as[String] shouldBe "nginx"
+    (json \ "spec" \ "rules").as[List[play.api.libs.json.JsValue]].size shouldBe 1
+  }
+
+  it should "extend ApplyConfiguration[Ingress]" in {
+    val ing: ApplyConfiguration[Ingress] = IngressApplyConfig("my-ingress")
+    ing.name shouldBe "my-ingress"
+  }
+
+  it should "support TLS configuration" in {
+    val spec = IngressSpecApplyConfig()
+      .addTLS(Ingress.TLS(hosts = List("example.com"), secretName = Some("tls-secret")))
+    spec.tls.get.size shouldBe 1
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/networking/NetworkPolicyApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/networking/NetworkPolicyApplyConfigSpec.scala
@@ -1,0 +1,48 @@
+package skuber.model.ac.networking
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.networking.NetworkPolicy
+import skuber.json.format._
+
+class NetworkPolicyApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "NetworkPolicyApplyConfig" should "be constructed by name" in {
+    val np = NetworkPolicyApplyConfig("my-policy")
+    np.name shouldBe "my-policy"
+    np.kind shouldBe "NetworkPolicy"
+    np.apiVersion shouldBe "networking.k8s.io/v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val np = NetworkPolicyApplyConfig("deny-all")
+      .withSpec(NetworkPolicySpecApplyConfig()
+        .withPodSelector(LabelSelector())
+        .withPolicyTypes(List("Ingress"))
+      )
+    val json = Json.toJson(np)
+    (json \ "kind").as[String] shouldBe "NetworkPolicy"
+    (json \ "spec" \ "policyTypes")(0).as[String] shouldBe "Ingress"
+  }
+
+  it should "extend ApplyConfiguration[NetworkPolicy]" in {
+    val np: ApplyConfiguration[NetworkPolicy] = NetworkPolicyApplyConfig("my-policy")
+    np.name shouldBe "my-policy"
+  }
+
+  it should "support ingress and egress rules" in {
+    val spec = NetworkPolicySpecApplyConfig()
+      .withPodSelector(LabelSelector())
+      .addIngressRule(NetworkPolicy.IngressRule(
+        from = List(NetworkPolicy.Peer(namespaceSelector = Some(LabelSelector())))
+      ))
+      .addEgressRule(NetworkPolicy.EgressRule(
+        to = List(NetworkPolicy.Peer(ipBlock = Some(NetworkPolicy.IPBlock("10.0.0.0/8"))))
+      ))
+    spec.ingress.get.size shouldBe 1
+    spec.egress.get.size shouldBe 1
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/policy/v1/PodDisruptionBudgetApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/policy/v1/PodDisruptionBudgetApplyConfigSpec.scala
@@ -1,0 +1,42 @@
+package skuber.model.ac.policy.v1
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.policy.v1.PodDisruptionBudget
+import skuber.json.format._
+
+class PodDisruptionBudgetApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "PodDisruptionBudgetApplyConfig" should "be constructed by name" in {
+    val pdb = PodDisruptionBudgetApplyConfig("my-pdb")
+    pdb.name shouldBe "my-pdb"
+    pdb.kind shouldBe "PodDisruptionBudget"
+    pdb.apiVersion shouldBe "policy/v1"
+  }
+
+  it should "serialize with spec fields" in {
+    val pdb = PodDisruptionBudgetApplyConfig("my-pdb")
+      .withSpec(PodDisruptionBudgetSpecApplyConfig()
+        .withMinAvailable(Left(2))
+        .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", "web")))
+      )
+    val json = Json.toJson(pdb)
+    (json \ "kind").as[String] shouldBe "PodDisruptionBudget"
+    (json \ "apiVersion").as[String] shouldBe "policy/v1"
+    (json \ "spec" \ "minAvailable").as[Int] shouldBe 2
+  }
+
+  it should "extend ApplyConfiguration[PodDisruptionBudget]" in {
+    val pdb: ApplyConfiguration[PodDisruptionBudget] = PodDisruptionBudgetApplyConfig("my-pdb")
+    pdb.name shouldBe "my-pdb"
+  }
+
+  it should "support maxUnavailable as percentage" in {
+    val spec = PodDisruptionBudgetSpecApplyConfig()
+      .withMaxUnavailable(Right("25%"))
+    spec.maxUnavailable shouldBe Some(Right("25%"))
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/rbac/ClusterRoleApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/rbac/ClusterRoleApplyConfigSpec.scala
@@ -1,0 +1,40 @@
+package skuber.model.ac.rbac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+class ClusterRoleApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ClusterRoleApplyConfig" should "be constructed by name" in {
+    val cr = ClusterRoleApplyConfig("my-clusterrole")
+    cr.name shouldBe "my-clusterrole"
+    cr.kind shouldBe "ClusterRole"
+    cr.apiVersion shouldBe "rbac.authorization.k8s.io/v1"
+  }
+
+  it should "serialize with rules" in {
+    val cr = ClusterRoleApplyConfig("my-clusterrole")
+      .addRule(PolicyRule(
+        apiGroups = List(""),
+        attributeRestrictions = None,
+        nonResourceURLs = Nil,
+        resourceNames = Nil,
+        resources = List("nodes"),
+        verbs = List("get", "list")
+      ))
+    val json = Json.toJson(cr)
+    (json \ "kind").as[String] shouldBe "ClusterRole"
+    (json \ "rules").as[List[play.api.libs.json.JsValue]].size shouldBe 1
+  }
+
+  it should "extend ApplyConfiguration[ClusterRole]" in {
+    val cr: ApplyConfiguration[ClusterRole] = ClusterRoleApplyConfig("my-clusterrole")
+    cr.name shouldBe "my-clusterrole"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/rbac/ClusterRoleBindingApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/rbac/ClusterRoleBindingApplyConfigSpec.scala
@@ -1,0 +1,35 @@
+package skuber.model.ac.rbac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+class ClusterRoleBindingApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "ClusterRoleBindingApplyConfig" should "be constructed by name" in {
+    val crb = ClusterRoleBindingApplyConfig("my-cluster-binding")
+    crb.name shouldBe "my-cluster-binding"
+    crb.kind shouldBe "ClusterRoleBinding"
+    crb.apiVersion shouldBe "rbac.authorization.k8s.io/v1"
+  }
+
+  it should "serialize with roleRef and subjects" in {
+    val crb = ClusterRoleBindingApplyConfig("my-cluster-binding")
+      .withRoleRef(RoleRef("rbac.authorization.k8s.io", "ClusterRole", "my-clusterrole"))
+      .addSubject(Subject(Some("rbac.authorization.k8s.io/v1"), "ServiceAccount", "default", Some("kube-system")))
+    val json = Json.toJson(crb)
+    (json \ "kind").as[String] shouldBe "ClusterRoleBinding"
+    (json \ "roleRef" \ "name").as[String] shouldBe "my-clusterrole"
+    (json \ "subjects")(0).as[play.api.libs.json.JsValue].\("name").as[String] shouldBe "default"
+  }
+
+  it should "extend ApplyConfiguration[ClusterRoleBinding]" in {
+    val crb: ApplyConfiguration[ClusterRoleBinding] = ClusterRoleBindingApplyConfig("my-cluster-binding")
+    crb.name shouldBe "my-cluster-binding"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/rbac/RoleApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/rbac/RoleApplyConfigSpec.scala
@@ -1,0 +1,40 @@
+package skuber.model.ac.rbac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+class RoleApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "RoleApplyConfig" should "be constructed by name" in {
+    val role = RoleApplyConfig("my-role")
+    role.name shouldBe "my-role"
+    role.kind shouldBe "Role"
+    role.apiVersion shouldBe "rbac.authorization.k8s.io/v1"
+  }
+
+  it should "serialize with rules" in {
+    val role = RoleApplyConfig("my-role")
+      .addRule(PolicyRule(
+        apiGroups = List(""),
+        attributeRestrictions = None,
+        nonResourceURLs = Nil,
+        resourceNames = Nil,
+        resources = List("pods"),
+        verbs = List("get", "list", "watch")
+      ))
+    val json = Json.toJson(role)
+    (json \ "kind").as[String] shouldBe "Role"
+    (json \ "rules").as[List[play.api.libs.json.JsValue]].size shouldBe 1
+  }
+
+  it should "extend ApplyConfiguration[Role]" in {
+    val role: ApplyConfiguration[Role] = RoleApplyConfig("my-role")
+    role.name shouldBe "my-role"
+  }
+}

--- a/core/src/test/scala/skuber/model/ac/rbac/RoleBindingApplyConfigSpec.scala
+++ b/core/src/test/scala/skuber/model/ac/rbac/RoleBindingApplyConfigSpec.scala
@@ -1,0 +1,35 @@
+package skuber.model.ac.rbac
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.Json
+import skuber.model._
+import skuber.model.ac._
+import skuber.model.authorization.rbac._
+import skuber.json.format._
+import skuber.json.authorization.rbac.format._
+
+class RoleBindingApplyConfigSpec extends AnyFlatSpec with Matchers {
+
+  "RoleBindingApplyConfig" should "be constructed by name" in {
+    val rb = RoleBindingApplyConfig("my-binding")
+    rb.name shouldBe "my-binding"
+    rb.kind shouldBe "RoleBinding"
+    rb.apiVersion shouldBe "rbac.authorization.k8s.io/v1"
+  }
+
+  it should "serialize with roleRef and subjects" in {
+    val rb = RoleBindingApplyConfig("my-binding")
+      .withRoleRef(RoleRef("rbac.authorization.k8s.io", "Role", "my-role"))
+      .addSubject(Subject(Some("rbac.authorization.k8s.io/v1"), "User", "jane", None))
+    val json = Json.toJson(rb)
+    (json \ "kind").as[String] shouldBe "RoleBinding"
+    (json \ "roleRef" \ "name").as[String] shouldBe "my-role"
+    (json \ "subjects")(0).as[play.api.libs.json.JsValue].\("name").as[String] shouldBe "jane"
+  }
+
+  it should "extend ApplyConfiguration[RoleBinding]" in {
+    val rb: ApplyConfiguration[RoleBinding] = RoleBindingApplyConfig("my-binding")
+    rb.name shouldBe "my-binding"
+  }
+}

--- a/integration/src/test/scala/skuber/AkkaServerSideApplySpec.scala
+++ b/integration/src/test/scala/skuber/AkkaServerSideApplySpec.scala
@@ -1,0 +1,3 @@
+package skuber
+
+class AkkaServerSideApplySpec extends ServerSideApplySpec with AkkaK8SFixture

--- a/integration/src/test/scala/skuber/PekkoServerSideApplySpec.scala
+++ b/integration/src/test/scala/skuber/PekkoServerSideApplySpec.scala
@@ -1,0 +1,6 @@
+package skuber
+
+/**
+ * Pekko-specific concrete implementation of ServerSideApplySpec integration tests.
+ */
+class PekkoServerSideApplySpec extends ServerSideApplySpec with PekkoK8SFixture

--- a/integration/src/test/scala/skuber/ServerSideApplySpec.scala
+++ b/integration/src/test/scala/skuber/ServerSideApplySpec.scala
@@ -62,7 +62,7 @@ abstract class ServerSideApplySpec extends K8SFixture with Eventually with Match
         _ = created.name shouldBe deploymentName
         _ = created.spec.flatMap(_.replicas) shouldBe Some(1)
 
-        _ = eventually(timeout(120.seconds), interval(3.seconds)) {
+        _ = eventually(timeout(200.seconds), interval(5.seconds)) {
           val d = Await.result(k8s.get[Deployment](deploymentName), 5.seconds)
           d.status.map(_.availableReplicas).getOrElse(0) should be >= 1
         }
@@ -87,7 +87,7 @@ abstract class ServerSideApplySpec extends K8SFixture with Eventually with Match
               .flatMap(_.containers.headOption)
               .map(_.image) shouldBe Some("nginx:1.27")
 
-        _ = eventually(timeout(120.seconds), interval(3.seconds)) {
+        _ = eventually(timeout(200.seconds), interval(5.seconds)) {
           val d = Await.result(k8s.get[Deployment](deploymentName), 5.seconds)
           d.status.map(_.availableReplicas).getOrElse(0) should be >= 2
         }

--- a/integration/src/test/scala/skuber/ServerSideApplySpec.scala
+++ b/integration/src/test/scala/skuber/ServerSideApplySpec.scala
@@ -1,0 +1,104 @@
+package skuber
+
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import skuber.api.client.{ApplyOptions, DeleteOptions, DeletePropagation, K8SException}
+import skuber.model.LabelSelector
+import skuber.model.apps.v1.Deployment
+import skuber.model.ac.apps.v1.{DeploymentApplyConfig, DeploymentSpecApplyConfig}
+import skuber.model.ac.{ContainerApplyConfig, PodTemplateSpecApplyConfig, PodSpecApplyConfig}
+import skuber.json.format._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.{Failure, Success}
+
+/**
+ * Shared integration tests for server-side apply operations that work with the Pekko client.
+ * The concrete fixture (PekkoK8SFixture) is mixed in via build configuration.
+ */
+abstract class ServerSideApplySpec extends K8SFixture with Eventually with Matchers {
+
+  val deploymentName: String = java.util.UUID.randomUUID().toString
+
+  behavior of "Server-side apply"
+
+  it should "create and modify a deployment via apply" in {
+    withK8sClient(test = { k8s =>
+      val fieldManager = "skuber-ssa-test"
+
+      val initialConfig = DeploymentApplyConfig(deploymentName)
+        .addLabel("app" -> deploymentName)
+        .withSpec(DeploymentSpecApplyConfig()
+          .withReplicas(1)
+          .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", deploymentName)))
+          .withTemplate(PodTemplateSpecApplyConfig()
+            .addLabel("app" -> deploymentName)
+            .withPodSpec(PodSpecApplyConfig()
+              .addContainer(ContainerApplyConfig("nginx", "nginx:1.25").exposePort(80))
+            )
+          )
+        )
+
+      for {
+        // Step 1: Apply config to CREATE the deployment
+        created <- k8s.apply[Deployment, DeploymentApplyConfig](initialConfig, ApplyOptions(fieldManager = fieldManager))
+
+        // Step 2: Verify it exists and has the expected replica count
+        _ = created.name shouldBe deploymentName
+        _ = created.spec.flatMap(_.replicas) shouldBe Some(1)
+
+        // Step 3: Wait for the deployment to become available (availableReplicas >= 1)
+        _ = eventually(timeout(120.seconds), interval(3.seconds)) {
+          val d = Await.result(k8s.get[Deployment](deploymentName), 5.seconds)
+          d.status.map(_.availableReplicas).getOrElse(0) should be >= 1
+        }
+
+        // Step 4: Apply a modified config to UPDATE via SSA (2 replicas, nginx:1.27)
+        updatedConfig = DeploymentApplyConfig(deploymentName)
+          .addLabel("app" -> deploymentName)
+          .withSpec(DeploymentSpecApplyConfig()
+            .withReplicas(2)
+            .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", deploymentName)))
+            .withTemplate(PodTemplateSpecApplyConfig()
+              .addLabel("app" -> deploymentName)
+              .withPodSpec(PodSpecApplyConfig()
+                .addContainer(ContainerApplyConfig("nginx", "nginx:1.27").exposePort(80))
+              )
+            )
+          )
+
+        updated <- k8s.apply[Deployment, DeploymentApplyConfig](updatedConfig, ApplyOptions(fieldManager = fieldManager))
+
+        // Step 5: Verify updated state (replicas=2, image=nginx:1.27)
+        _ = updated.spec.flatMap(_.replicas) shouldBe Some(2)
+        _ = updated.spec
+              .flatMap(_.template.spec)
+              .flatMap(_.containers.headOption)
+              .map(_.image) shouldBe Some("nginx:1.27")
+
+        // Step 6: Wait for the updated deployment to reach desired state
+        _ = eventually(timeout(120.seconds), interval(3.seconds)) {
+          val d = Await.result(k8s.get[Deployment](deploymentName), 5.seconds)
+          d.status.map(_.availableReplicas).getOrElse(0) should be >= 2
+        }
+
+        // Step 7: Clean up: delete the deployment
+        _ <- k8s.deleteWithOptions[Deployment](deploymentName, DeleteOptions(propagationPolicy = Some(DeletePropagation.Foreground)))
+
+        // Wait for deletion to complete
+        result = eventually(timeout(120.seconds), interval(3.seconds)) {
+          val attempt = Await.ready(k8s.get[Deployment](deploymentName), 5.seconds).value.get
+          attempt match {
+            case Success(_) => fail("Deleted deployment still exists")
+            case Failure(ex) => ex match {
+              case ex: K8SException if ex.status.code.contains(404) => succeed
+              case _ => fail(s"Unexpected exception: ${ex.getMessage}")
+            }
+          }
+        }
+      } yield result
+    }, timeout = 600.seconds)
+  }
+}

--- a/integration/src/test/scala/skuber/ServerSideApplySpec.scala
+++ b/integration/src/test/scala/skuber/ServerSideApplySpec.scala
@@ -9,10 +9,10 @@ import skuber.model.ac.apps.v1.{DeploymentApplyConfig, DeploymentSpecApplyConfig
 import skuber.model.ac.{ContainerApplyConfig, PodTemplateSpecApplyConfig, PodSpecApplyConfig}
 import skuber.json.format._
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 /**
  * Shared integration tests for server-side apply operations that work with the Pekko client.
@@ -41,21 +41,32 @@ abstract class ServerSideApplySpec extends K8SFixture with Eventually with Match
           )
         )
 
-      for {
-        // Step 1: Apply config to CREATE the deployment
-        created <- k8s.apply[Deployment, DeploymentApplyConfig](initialConfig, ApplyOptions(fieldManager = fieldManager))
+      def cleanup(): Future[Unit] =
+        k8s.deleteWithOptions[Deployment](deploymentName, DeleteOptions(propagationPolicy = Some(DeletePropagation.Foreground)))
+          .recover { case _ => () }
+          .flatMap { _ =>
+            Future {
+              eventually(timeout(120.seconds), interval(3.seconds)) {
+                val attempt = Await.ready(k8s.get[Deployment](deploymentName), 5.seconds).value.get
+                attempt match {
+                  case Failure(ex: K8SException) if ex.status.code.contains(404) => ()
+                  case _ => throw new AssertionError("Deployment still exists after deletion")
+                }
+              }
+            }
+          }
+          .recover { case _ => () }
 
-        // Step 2: Verify it exists and has the expected replica count
+      val testResult = for {
+        created <- k8s.apply[Deployment, DeploymentApplyConfig](initialConfig, ApplyOptions(fieldManager = fieldManager))
         _ = created.name shouldBe deploymentName
         _ = created.spec.flatMap(_.replicas) shouldBe Some(1)
 
-        // Step 3: Wait for the deployment to become available (availableReplicas >= 1)
         _ = eventually(timeout(120.seconds), interval(3.seconds)) {
           val d = Await.result(k8s.get[Deployment](deploymentName), 5.seconds)
           d.status.map(_.availableReplicas).getOrElse(0) should be >= 1
         }
 
-        // Step 4: Apply a modified config to UPDATE via SSA (2 replicas, nginx:1.27)
         updatedConfig = DeploymentApplyConfig(deploymentName)
           .addLabel("app" -> deploymentName)
           .withSpec(DeploymentSpecApplyConfig()
@@ -70,35 +81,26 @@ abstract class ServerSideApplySpec extends K8SFixture with Eventually with Match
           )
 
         updated <- k8s.apply[Deployment, DeploymentApplyConfig](updatedConfig, ApplyOptions(fieldManager = fieldManager))
-
-        // Step 5: Verify updated state (replicas=2, image=nginx:1.27)
         _ = updated.spec.flatMap(_.replicas) shouldBe Some(2)
         _ = updated.spec
               .flatMap(_.template.spec)
               .flatMap(_.containers.headOption)
               .map(_.image) shouldBe Some("nginx:1.27")
 
-        // Step 6: Wait for the updated deployment to reach desired state
         _ = eventually(timeout(120.seconds), interval(3.seconds)) {
           val d = Await.result(k8s.get[Deployment](deploymentName), 5.seconds)
           d.status.map(_.availableReplicas).getOrElse(0) should be >= 2
         }
+      } yield succeed
 
-        // Step 7: Clean up: delete the deployment
-        _ <- k8s.deleteWithOptions[Deployment](deploymentName, DeleteOptions(propagationPolicy = Some(DeletePropagation.Foreground)))
-
-        // Wait for deletion to complete
-        result = eventually(timeout(120.seconds), interval(3.seconds)) {
-          val attempt = Await.ready(k8s.get[Deployment](deploymentName), 5.seconds).value.get
-          attempt match {
-            case Success(_) => fail("Deleted deployment still exists")
-            case Failure(ex) => ex match {
-              case ex: K8SException if ex.status.code.contains(404) => succeed
-              case _ => fail(s"Unexpected exception: ${ex.getMessage}")
-            }
+      testResult.transformWith { result =>
+        cleanup().flatMap { _ =>
+          result match {
+            case Success(a) => Future.successful(a)
+            case Failure(e) => Future.failed(e)
           }
         }
-      } yield result
+      }
     }, timeout = 600.seconds)
   }
 }

--- a/pekko/src/main/scala/skuber/pekkoclient/impl/PekkoKubernetesClientImpl.scala
+++ b/pekko/src/main/scala/skuber/pekkoclient/impl/PekkoKubernetesClientImpl.scala
@@ -17,6 +17,7 @@ import skuber.pekkoclient.watch.{LongPollingPool, PekkoWatcherImpl, Watch, Watch
 import skuber.pekkoclient.exec.PodExecImpl
 import skuber.api.client._
 import skuber.api.patch._
+import skuber.model.ac.ApplyConfiguration
 import skuber.api.security.TLS
 import PlayJsonSupportForPekkoHttp._
 import skuber.api.client
@@ -521,6 +522,23 @@ class PekkoKubernetesClientImpl private[pekkoclient] (
     for {
       requestEntity <- marshal.to[RequestEntity]
       httpRequest <- buildRequest(HttpMethods.PATCH, rd, Some(name), namespaceOverride = Some(targetNamespace))
+      requestWithEntity = httpRequest.withEntity(requestEntity.withContentType(contentType))
+      newOrUpdatedResource <- makeRequestReturningObjectResource[O](requestWithEntity)
+    } yield newOrUpdatedResource
+  }
+
+  override def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(
+    implicit writes: Writes[AC], fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Future[O] = {
+    val contentType = CustomMediaTypes.`application/apply-patch+json`
+    val queryMap = scala.collection.mutable.Map("fieldManager" -> options.fieldManager)
+    if (options.force) queryMap += ("force" -> "true")
+    val query = Some(Uri.Query(queryMap.toMap))
+    logInfo(logConfig.logRequestBasicMetadata, s"Requesting apply of resource: { name:${applyConfig.name}, fieldManager:${options.fieldManager} ... }")
+    logInfo(logConfig.logRequestFullObjectResource, s" Marshal and send: ${applyConfig.toString}")
+    val marshal = Marshal(applyConfig)
+    for {
+      requestEntity <- marshal.to[RequestEntity]
+      httpRequest <- buildRequest(HttpMethods.PATCH, rd, Some(applyConfig.name), query = query)
       requestWithEntity = httpRequest.withEntity(requestEntity.withContentType(contentType))
       newOrUpdatedResource <- makeRequestReturningObjectResource[O](requestWithEntity)
     } yield newOrUpdatedResource

--- a/pekko/src/main/scala/skuber/pekkoclient/impl/PekkoKubernetesClientImpl.scala
+++ b/pekko/src/main/scala/skuber/pekkoclient/impl/PekkoKubernetesClientImpl.scala
@@ -529,7 +529,7 @@ class PekkoKubernetesClientImpl private[pekkoclient] (
 
   override def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(
     implicit writes: Writes[AC], fmt: Format[O], rd: ResourceDefinition[O], lc: LoggingContext): Future[O] = {
-    val contentType = CustomMediaTypes.`application/apply-patch+json`
+    val contentType = CustomMediaTypes.`application/apply-patch+yaml`
     val queryMap = scala.collection.mutable.Map("fieldManager" -> options.fieldManager)
     if (options.force) queryMap += ("force" -> "true")
     val query = Some(Uri.Query(queryMap.toMap))

--- a/pekko/src/main/scala/skuber/pekkoclient/package.scala
+++ b/pekko/src/main/scala/skuber/pekkoclient/package.scala
@@ -20,7 +20,7 @@ package object pekkoclient {
   object CustomMediaTypes {
     val `application/merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("merge-patch+json", HttpCharsets.`UTF-8`)
     val `application/strategic-merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("strategic-merge-patch+json", HttpCharsets.`UTF-8`)
-    val `application/apply-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("apply-patch+json", HttpCharsets.`UTF-8`)
+    val `application/apply-patch+yaml`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("apply-patch+yaml", HttpCharsets.`UTF-8`)
   }
 
   type Pool[T] = Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed]

--- a/pekko/src/main/scala/skuber/pekkoclient/package.scala
+++ b/pekko/src/main/scala/skuber/pekkoclient/package.scala
@@ -20,6 +20,7 @@ package object pekkoclient {
   object CustomMediaTypes {
     val `application/merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("merge-patch+json", HttpCharsets.`UTF-8`)
     val `application/strategic-merge-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("strategic-merge-patch+json", HttpCharsets.`UTF-8`)
+    val `application/apply-patch+json`: MediaType.WithFixedCharset = MediaType.applicationWithFixedCharset("apply-patch+json", HttpCharsets.`UTF-8`)
   }
 
   type Pool[T] = Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed]

--- a/zio-it/src/test/scala/skuber/zioit/ZioAllSpecs.scala
+++ b/zio-it/src/test/scala/skuber/zioit/ZioAllSpecs.scala
@@ -24,5 +24,6 @@ object ZioAllSpecs extends ZIOSpecDefault:
     ZioPodLogSpec.spec,
     ZioExecSpec.spec,
     ZioCustomResourceSpec.spec,
-    ZioWatchSpec.spec
+    ZioWatchSpec.spec,
+    ZioServerSideApplySpec.spec
   ).provideLayerShared(ZKubernetesClient.layer) @@ TestAspect.sequential @@ TestAspect.withLiveClock

--- a/zio-it/src/test/scala/skuber/zioit/ZioServerSideApplySpec.scala
+++ b/zio-it/src/test/scala/skuber/zioit/ZioServerSideApplySpec.scala
@@ -1,0 +1,82 @@
+package skuber.zioit
+
+import zio.*
+import zio.test.*
+import zio.test.test
+import skuber.api.client.{ApplyOptions, DeleteOptions, DeletePropagation}
+import skuber.json.format.*
+import skuber.model.LabelSelector
+import skuber.model.LabelSelector.dsl.*
+import skuber.model.ac.apps.v1.{DeploymentApplyConfig, DeploymentSpecApplyConfig}
+import skuber.model.ac.{ContainerApplyConfig, PodSpecApplyConfig, PodTemplateSpecApplyConfig}
+import skuber.model.apps.v1.Deployment
+import skuber.zio.ZKubernetesClient
+import skuber.zioit.TestHelpers.*
+
+object ZioServerSideApplySpec:
+
+  def spec = suite("ZIO Server-Side Apply")(
+
+    test("server-side apply creates and updates a deployment") {
+      ZIO.serviceWithZIO[ZKubernetesClient] { k8s =>
+        val name = java.util.UUID.randomUUID().toString
+        val fieldManager = "skuber-ssa-test"
+
+        val initialConfig = DeploymentApplyConfig(name)
+          .addLabel("app" -> name)
+          .withSpec(DeploymentSpecApplyConfig()
+            .withReplicas(1)
+            .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", name)))
+            .withTemplate(PodTemplateSpecApplyConfig()
+              .addLabel("app" -> name)
+              .withPodSpec(PodSpecApplyConfig()
+                .addContainer(ContainerApplyConfig("nginx", "nginx:1.25").exposePort(80))
+              )
+            )
+          )
+
+        val updatedConfig = DeploymentApplyConfig(name)
+          .addLabel("app" -> name)
+          .withSpec(DeploymentSpecApplyConfig()
+            .withReplicas(2)
+            .withSelector(LabelSelector(LabelSelector.IsEqualRequirement("app", name)))
+            .withTemplate(PodTemplateSpecApplyConfig()
+              .addLabel("app" -> name)
+              .withPodSpec(PodSpecApplyConfig()
+                .addContainer(ContainerApplyConfig("nginx", "nginx:1.27").exposePort(80))
+              )
+            )
+          )
+
+        val cleanup =
+          k8s.deleteWithOptions[Deployment](name, DeleteOptions(propagationPolicy = Some(DeletePropagation.Foreground)))
+            .flatMap(_ => retryUntilGone(k8s.get[Deployment](name), retries = 40, delay = 3.seconds))
+            .ignoreLogged
+
+        val testLogic = for
+          created <- k8s.apply[Deployment, DeploymentApplyConfig](initialConfig, ApplyOptions(fieldManager = fieldManager))
+          _ = assert(created.name == name)
+          _ = assert(created.spec.flatMap(_.replicas).contains(1))
+
+          _ <- retryUntil(
+            k8s.get[Deployment](name).map(d => d.status.exists(_.availableReplicas >= 1)),
+            retries = 40, delay = 3.seconds, label = "availableReplicas >= 1"
+          )
+
+          updated <- k8s.apply[Deployment, DeploymentApplyConfig](updatedConfig, ApplyOptions(fieldManager = fieldManager))
+          _ = assert(updated.spec.flatMap(_.replicas).contains(2))
+          _ = assert(
+            updated.spec.flatMap(_.template.spec).flatMap(_.containers.headOption).map(_.image).contains("nginx:1.27")
+          )
+
+          _ <- retryUntil(
+            k8s.get[Deployment](name).map(d => d.status.exists(_.availableReplicas >= 2)),
+            retries = 40, delay = 3.seconds, label = "availableReplicas >= 2"
+          )
+        yield assertTrue(true)
+
+        testLogic.ensuring(cleanup)
+      }
+    }
+
+  )

--- a/zio-it/src/test/scala/skuber/zioit/ZioServerSideApplySpec.scala
+++ b/zio-it/src/test/scala/skuber/zioit/ZioServerSideApplySpec.scala
@@ -60,7 +60,7 @@ object ZioServerSideApplySpec:
 
           _ <- retryUntil(
             k8s.get[Deployment](name).map(d => d.status.exists(_.availableReplicas >= 1)),
-            retries = 40, delay = 3.seconds, label = "availableReplicas >= 1"
+            retries = 40, delay = 5.seconds, label = "availableReplicas >= 1"
           )
 
           updated <- k8s.apply[Deployment, DeploymentApplyConfig](updatedConfig, ApplyOptions(fieldManager = fieldManager))
@@ -71,7 +71,7 @@ object ZioServerSideApplySpec:
 
           _ <- retryUntil(
             k8s.get[Deployment](name).map(d => d.status.exists(_.availableReplicas >= 2)),
-            retries = 40, delay = 3.seconds, label = "availableReplicas >= 2"
+            retries = 40, delay = 5.seconds, label = "availableReplicas >= 2"
           )
         yield assertTrue(true)
 

--- a/zio/src/main/scala/skuber/zio/ZKubernetesClient.scala
+++ b/zio/src/main/scala/skuber/zio/ZKubernetesClient.scala
@@ -3,8 +3,9 @@ package skuber.zio
 import zio.*
 import zio.stream.*
 import play.api.libs.json.{Format, Writes}
-import skuber.api.client.{K8SException, WatchEvent, WatchParameters, ListOptions, DeleteOptions}
+import skuber.api.client.{K8SException, WatchEvent, WatchParameters, ListOptions, DeleteOptions, ApplyOptions}
 import skuber.api.patch.Patch
+import skuber.model.ac.ApplyConfiguration
 import skuber.model.*
 
 trait ZKubernetesClient:
@@ -21,6 +22,7 @@ trait ZKubernetesClient:
   def getScale[O <: ObjectResource](name: String)(using ResourceDefinition[O], Scale.SubresourceSpec[O]): IO[K8SException, Scale]
   def updateScale[O <: ObjectResource](name: String, scale: Scale)(using ResourceDefinition[O], Scale.SubresourceSpec[O]): IO[K8SException, Scale]
   def patch[P <: Patch, O <: ObjectResource](name: String, patchData: P, namespace: Option[String] = None)(using Writes[P], Format[O], ResourceDefinition[O]): IO[K8SException, O]
+  def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(using Writes[AC], Format[O], ResourceDefinition[O]): IO[K8SException, O]
   def watch[O <: ObjectResource](params: WatchParameters = WatchParameters())(using Format[O], ResourceDefinition[O]): ZStream[Any, K8SException, WatchEvent[O]]
   def getPodLogStream(name: String, queryParams: Pod.LogQueryParams = Pod.LogQueryParams(), namespace: Option[String] = None): ZStream[Any, Throwable, Byte]
   def exec(podName: String, command: Seq[String], containerName: Option[String] = None, stdin: Option[ZStream[Any, Nothing, String]] = None, tty: Boolean = false): ZStream[Any, Throwable, ExecOutput]

--- a/zio/src/main/scala/skuber/zio/internal/ZKubernetesClientImpl.scala
+++ b/zio/src/main/scala/skuber/zio/internal/ZKubernetesClientImpl.scala
@@ -139,7 +139,7 @@ private[zio] class ZKubernetesClientImpl(
     val url = UrlBuilder.resourceUrl(clusterServer, namespace, rd, Some(applyConfig.name))
     val body = PlayJsonBridge.encode(applyConfig)
     val queryParams = Seq("fieldManager" -> options.fieldManager) ++ (if options.force then Seq("force" -> "true") else Seq.empty)
-    executeRequest(K8sRequest(HttpMethod.Patch, url, body = Some(body), headers = Map("Content-Type" -> "application/apply-patch+json"), queryParams = queryParams)).flatMap(parseResponse[O])
+    executeRequest(K8sRequest(HttpMethod.Patch, url, body = Some(body), headers = Map("Content-Type" -> "application/apply-patch+yaml"), queryParams = queryParams)).flatMap(parseResponse[O])
 
   override def getServerAPIVersions: IO[K8SException, List[String]] =
     val req = K8sRequest(HttpMethod.Get, s"$clusterServer/api")

--- a/zio/src/main/scala/skuber/zio/internal/ZKubernetesClientImpl.scala
+++ b/zio/src/main/scala/skuber/zio/internal/ZKubernetesClientImpl.scala
@@ -5,6 +5,7 @@ import zio.stream.*
 import play.api.libs.json.{Format, Json, Writes}
 import skuber.api.client.*
 import skuber.api.patch.{JsonMergePatchStrategy, JsonPatchStrategy, Patch, StrategicMergePatchStrategy}
+import skuber.model.ac.ApplyConfiguration
 import skuber.internal.{HttpMethod, K8sRequest, K8sResponse, UrlBuilder}
 import skuber.json.format.deleteOptionsFmt
 import skuber.json.format.apiobj.statusReads
@@ -132,6 +133,13 @@ private[zio] class ZKubernetesClientImpl(
       case JsonPatchStrategy           => "application/json-patch+json"
     val body = PlayJsonBridge.encode(patchData)
     executeRequest(K8sRequest(HttpMethod.Patch, url, body = Some(body), headers = Map("Content-Type" -> contentType))).flatMap(parseResponse[O])
+
+  override def apply[O <: ObjectResource, AC <: ApplyConfiguration[O]](applyConfig: AC, options: ApplyOptions)(using Writes[AC], Format[O], ResourceDefinition[O]): IO[K8SException, O] =
+    val rd  = summon[ResourceDefinition[O]]
+    val url = UrlBuilder.resourceUrl(clusterServer, namespace, rd, Some(applyConfig.name))
+    val body = PlayJsonBridge.encode(applyConfig)
+    val queryParams = Seq("fieldManager" -> options.fieldManager) ++ (if options.force then Seq("force" -> "true") else Seq.empty)
+    executeRequest(K8sRequest(HttpMethod.Patch, url, body = Some(body), headers = Map("Content-Type" -> "application/apply-patch+json"), queryParams = queryParams)).flatMap(parseResponse[O])
 
   override def getServerAPIVersions: IO[K8SException, List[String]] =
     val req = K8sRequest(HttpMethod.Get, s"$clusterServer/api")


### PR DESCRIPTION
Major new feature implementing the Kubernetes Server Side Apply (SSA) functionality.
SSA is very useful especially for controllers/operators - for example to avoid race conditions when updating resources. See https://kubernetes.io/docs/reference/using-api/server-side-apply/.

The implementation adds a new `apply` method to each client API that creates or updates a resource based on `apply configurations` which are typed according to the resource kind. These apply configurations contain the values of the various fields that the application seeks to set when it uses apply to create/update a resource.

The `skuber.model.ac` package contains the apply configuration classes for the different  supported built-in resource kinds  (the original model case classes are not suitable as apply configurations because they generally contain mandatory fields that would override values on the resource when applied even if changing that setting was not the requirement / intention).

It also adds unit tests and (for each client) integration tests for this new feature.
