### PR TITLE
Rewrite kubeconfig handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,9 @@ val commonsIO = "commons-io" % "commons-io" % "2.22.0"
 val typesafeConfig = "com.typesafe" % "config" % "1.4.9"
 val logback = "ch.qos.logback" % "logback-classic" % "1.5.34" % Runtime
 val playJson = "org.playframework" %% "play-json" % "3.0.6"
+// Already present transitively via play-json, but declared explicitly since core's kubeconfig
+// parser (skuber.api.kubeconfig) uses the Jackson ObjectMapper API directly at compile time.
+val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.3"
 
 scalacOptions += "-target:jvm-1.8"
 
@@ -57,7 +60,7 @@ lazy val commonSettings = Seq(
 // skuber core - contains the skuber model and core API - has no dependencies on Akka/Pekko
 lazy val skuberSettings = Seq(
   libraryDependencies ++= Seq(
-    playJson, snakeYaml, commonsIO, commonsCodec,
+    playJson, snakeYaml, commonsIO, commonsCodec, jacksonDatabind,
     scalaCheck % Test, specs2 % Test, mockito % Test, scalaTestMockito % Test,
     scalaTest % Test
   ).map(_.exclude("commons-logging", "commons-logging"))

--- a/core/src/main/scala/skuber/api/Configuration.scala
+++ b/core/src/main/scala/skuber/api/Configuration.scala
@@ -1,13 +1,8 @@
 package skuber.api
 
 import java.net.URI
-import java.time.Instant
-import java.time.format.DateTimeFormatter
-import scala.collection.JavaConverters._
 import scala.util.Try
 import scala.util.Failure
-import java.util.{ Base64, Date }
-import org.yaml.snakeyaml.Yaml
 
 import skuber.api.client._
 import skuber.model.Namespace
@@ -47,13 +42,6 @@ object Configuration {
       clusters = Map("default" -> defaultCluster),
       contexts= Map("default" -> defaultContext),
       currentContext = defaultContext)
-  }
-
-  // This covers most of RFC3339
-  private val DateFormatters = List(DateTimeFormatter.ISO_INSTANT, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-  private def parseInstant(s: String): Instant = {
-    DateFormatters.collectFirst(Function.unlift(format => Try(Instant.from(format.parse(s))).toOption))
-      .getOrElse(sys.error(s"'$s' could not be parsed as a date time string"))
   }
 
   // config to use a local proxy running on a specified port
@@ -98,137 +86,8 @@ object Configuration {
       }
     }
 
-    def parseKubeconfigStream(is: java.io.InputStream, kubeconfigDir: Option[Path] = None) : Try[Configuration]= {
-
-      type YamlMap = java.util.Map[String, Object]
-      type TopLevelYamlList = java.util.List[YamlMap]
-
-      Try {
-        val yaml = new Yaml()
-        val mainConfig = yaml.load(is).asInstanceOf[YamlMap]
-
-        def name(parent: YamlMap) =
-          parent.get("name").asInstanceOf[String]
-
-        def child(parent: YamlMap, key: String) =
-          parent.get(key).asInstanceOf[YamlMap]
-
-        def topLevelList(key: String) =
-          mainConfig.get(key).asInstanceOf[TopLevelYamlList]
-
-        def valueAt[T](parent: YamlMap, key: String, fallback: Option[T] = None) : T =
-          parent.asScala.get(key).orElse(fallback).get.asInstanceOf[T]
-
-        def optionalInstantValueAt[T](parent: YamlMap, key: String) : Option[Instant] =
-          parent.asScala.get(key).flatMap {
-            case d: Date => Some(d.toInstant)
-            case s: String => Try(parseInstant(s)).toOption
-            case _ => None
-          }
-
-        def optionalValueAt[T](parent: YamlMap, key: String) : Option[T] =
-          parent.asScala.get(key).map(_.asInstanceOf[T])
-
-        def pathOrDataValueAt[T](parent: YamlMap, pathKey: String, dataKey: String) : Option[PathOrData] = {
-          val path = optionalValueAt[String](parent, pathKey)
-          val data = optionalValueAt[String](parent, dataKey)
-
-          // Return some Right if data value is set, otherwise some Left if path value is set
-          // if neither is set return None
-          // Note - implication is that a data setting overrides a path setting
-          (path, data) match {
-            case (_, Some(b64EncodedData)) => Some(Right(Base64.getDecoder.decode(b64EncodedData)))
-            case (Some(p), _) =>
-              // path specified
-              // if it is a relative path and a directory was specified then construct full path from those components,
-              // otherwise just return path as given
-              val expandedPath = (Paths.get(p), kubeconfigDir) match {
-                case (basePath, Some(dir)) if !basePath.isAbsolute =>
-                  Paths.get(dir.normalize.toString, basePath.normalize.toString).normalize.toString
-                case _  => p
-              }
-              Some(Left(expandedPath))
-            case (None, None) => None
-          }
-        }
-
-        def topLevelYamlToK8SConfigMap[K8SConfigKind](kind: String, toK8SConfig: YamlMap=> K8SConfigKind) =
-          topLevelList(kind + "s").asScala.map(item => name(item) -> toK8SConfig(child(item, kind))).toMap
-
-
-        def toK8SCluster(clusterConfig: YamlMap) =
-          Cluster(
-            apiVersion=valueAt(clusterConfig, "api-version", Some("v1")),
-            server=valueAt(clusterConfig,"server",Some("http://localhost:8001")),
-            insecureSkipTLSVerify=valueAt(clusterConfig,"insecure-skip-tls-verify",Some(false)),
-            certificateAuthority=pathOrDataValueAt(clusterConfig, "certificate-authority","certificate-authority-data")
-          )
-
-
-        val k8sClusterMap = topLevelYamlToK8SConfigMap("cluster", toK8SCluster)
-
-        def toK8SAuthInfo(userConfig:YamlMap): AuthInfo = {
-
-          def authProviderRead(authProvider: YamlMap): Option[AuthProviderAuth] = {
-            val config = child(authProvider, "config")
-            name(authProvider).toLowerCase match {
-              case "oidc" =>
-                Some(OidcAuth(idToken = valueAt(config, "id-token")))
-              case "gcp" =>
-                Some(
-                  GcpAuth(
-                    accessToken = optionalValueAt(config, "access-token"),
-                    expiry = optionalInstantValueAt(config, "expiry"),
-                    cmdPath = valueAt(config, "cmd-path"),
-                    cmdArgs = valueAt(config, "cmd-args")
-                  )
-                )
-              case _ => None
-            }
-          }
-
-          val maybeAuth = optionalValueAt[YamlMap](userConfig, "auth-provider") match {
-            case Some(authProvider) => authProviderRead(authProvider)
-            case None =>
-              val clientCertificate = pathOrDataValueAt(userConfig, "client-certificate", "client-certificate-data")
-              val clientKey = pathOrDataValueAt(userConfig, "client-key", "client-key-data")
-
-              val token = optionalValueAt[String](userConfig, "token")
-
-              val userName = optionalValueAt[String](userConfig, "username")
-              val password = optionalValueAt[String](userConfig, "password")
-
-              (userName, password, token, clientCertificate, clientKey) match {
-                case (Some(u), Some(p), _, _, _) => Some(BasicAuth(u, p))
-                case (_, _, Some(t), _, _) => Some(TokenAuth(t))
-                case (u, _, _, Some(cert), Some(key)) => Some(CertAuth(cert, key, u))
-                case _ => None
-              }
-          }
-
-          maybeAuth.getOrElse(NoAuth)
-        }
-        val k8sAuthInfoMap = topLevelYamlToK8SConfigMap("user", toK8SAuthInfo)
-
-        def toK8SContext(contextConfig: YamlMap) = {
-          val cluster=contextConfig.asScala.get("cluster").filterNot(_.asInstanceOf[String] == "").flatMap { clusterName =>
-            k8sClusterMap.get(clusterName.asInstanceOf[String])
-          }.getOrElse(Cluster())
-          val authInfo =contextConfig.asScala.get("user").filterNot(_.asInstanceOf[String] == "").flatMap { userKey =>
-            k8sAuthInfoMap.get(userKey.asInstanceOf[String])
-          }.getOrElse(NoAuth)
-          val namespace=contextConfig.asScala.get("namespace").fold(Namespace.default) { name=>Namespace.forName(name.asInstanceOf[String]) }
-          Context(cluster,authInfo,namespace)
-        }
-
-        val k8sContextMap = topLevelYamlToK8SConfigMap("context", toK8SContext)
-
-        val currentContextStr: Option[String] = optionalValueAt(mainConfig, "current-context")
-        val currentContext = currentContextStr.flatMap(k8sContextMap.get).getOrElse(Context())
-
-        Configuration(k8sClusterMap, k8sContextMap, currentContext, k8sAuthInfoMap)
-      }
-    }
+    def parseKubeconfigStream(is: java.io.InputStream, kubeconfigDir: Option[Path] = None) : Try[Configuration] =
+      skuber.api.kubeconfig.KubeconfigConverter.parse(is, kubeconfigDir)
 
   private lazy val inClusterConfigReloadInterval: Option[FiniteDuration] = {
     import scala.concurrent.duration._

--- a/core/src/main/scala/skuber/api/kubeconfig/ExecCredentialProtocol.scala
+++ b/core/src/main/scala/skuber/api/kubeconfig/ExecCredentialProtocol.scala
@@ -1,0 +1,75 @@
+package skuber.api.kubeconfig
+
+import java.time.Instant
+
+import play.api.libs.json._
+
+import scala.util.control.NonFatal
+
+/**
+ * Wire format for the `client.authentication.k8s.io` exec credential plugin protocol - structurally
+ * identical between `v1` (https://kubernetes.io/docs/reference/config-api/client-authentication.v1/) and
+ * `v1beta1` (https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/), so a single
+ * implementation handles both (the `apiVersion` string used is simply whatever the kubeconfig's
+ * `exec.apiVersion` says, echoed back in the request so the plugin knows which schema to reply with).
+ */
+private[kubeconfig] final case class ExecClusterInfo(
+  server: String,
+  certificateAuthorityDataBase64: Option[String],
+  insecureSkipTLSVerify: Boolean
+)
+
+private[kubeconfig] sealed trait ExecCredentialResult
+private[kubeconfig] final case class ExecToken(token: String, expiresAt: Option[Instant]) extends ExecCredentialResult
+private[kubeconfig] final case class ExecClientCert(certificatePem: Array[Byte], keyPem: Array[Byte]) extends ExecCredentialResult
+
+private[kubeconfig] object ExecCredentialProtocol {
+
+  /**
+   * Builds the JSON that is passed to the plugin via the `KUBERNETES_EXEC_INFO` environment variable:
+   * an `ExecCredential` object with an empty `status` and a `spec` describing this (non-interactive)
+   * invocation, plus cluster connection info when the exec config asked for it (`provideClusterInfo: true`).
+   */
+  def buildRequestJson(apiVersion: String, clusterInfo: Option[ExecClusterInfo]): String = {
+    val clusterJson: Option[JsObject] = clusterInfo.map { ci =>
+      JsObject(
+        Seq(
+          "server" -> Json.toJson(ci.server),
+          "insecure-skip-tls-verify" -> Json.toJson(ci.insecureSkipTLSVerify)
+        ) ++ ci.certificateAuthorityDataBase64.map(d => "certificate-authority-data" -> Json.toJson(d)).toSeq
+      )
+    }
+    val spec = JsObject(Seq("interactive" -> Json.toJson(false)) ++ clusterJson.map(c => "cluster" -> (c: JsValue)).toSeq)
+    val request = Json.obj(
+      "apiVersion" -> apiVersion,
+      "kind" -> "ExecCredential",
+      "spec" -> spec
+    )
+    Json.stringify(request)
+  }
+
+  /**
+   * Parses the plugin's stdout. Deliberately not expressed as a `Reads[ExecCredentialResult]`: we want
+   * precise, human-readable failure messages (missing `status`, neither token nor cert present) rather
+   * than a generic `JsError`.
+   */
+  def parseResponse(stdout: String): ExecCredentialResult = {
+    val json =
+      try Json.parse(stdout)
+      catch { case NonFatal(e) => sys.error(s"credential plugin returned output that isn't valid JSON: ${e.getMessage}") }
+    val status = (json \ "status").toOption.getOrElse(sys.error("credential plugin returned no 'status' field"))
+
+    val token = (status \ "token").asOpt[String]
+    val expiresAt = (status \ "expirationTimestamp").toOption.flatMap(KubeconfigInstant.parseLenient)
+    val certData = (status \ "clientCertificateData").asOpt[String]
+    val keyData = (status \ "clientKeyData").asOpt[String]
+
+    (token, certData, keyData) match {
+      case (Some(t), _, _) => ExecToken(t, expiresAt)
+      case (None, Some(c), Some(k)) => ExecClientCert(base64Decode(c), base64Decode(k))
+      case _ => sys.error("credential plugin returned neither a token nor a client certificate/key pair in its status")
+    }
+  }
+
+  private def base64Decode(s: String): Array[Byte] = java.util.Base64.getDecoder.decode(s)
+}

--- a/core/src/main/scala/skuber/api/kubeconfig/ExecCredentialRunner.scala
+++ b/core/src/main/scala/skuber/api/kubeconfig/ExecCredentialRunner.scala
@@ -1,0 +1,57 @@
+package skuber.api.kubeconfig
+
+import scala.sys.process.{Process, ProcessLogger}
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/**
+ * Runs a kubeconfig `exec`-configured credential plugin (e.g. `aws eks get-token`,
+ * `gke-gcloud-auth-plugin`, `tsh kube credentials`) and parses its response, per the
+ * `client.authentication.k8s.io` v1/v1beta1 protocol (see [[ExecCredentialProtocol]]).
+ *
+ * This is purely synchronous/blocking - callers (see `KubeconfigConverter`) are responsible for
+ * running it off whatever thread pool is appropriate for a blocking subprocess call.
+ *
+ * Note: no timeout is imposed on the child process. A misconfigured or hanging plugin (e.g. one
+ * waiting on an interactive prompt it will never receive) will block the calling thread/Future
+ * indefinitely. This is a known limitation.
+ */
+private[kubeconfig] object ExecCredentialRunner {
+
+  def run(exec: RawExecConfig, clusterInfo: Option[ExecClusterInfo]): Try[ExecCredentialResult] = Try {
+    if (exec.interactiveMode == "Always") {
+      sys.error(
+        s"credential plugin '${exec.command}' requires interactiveMode=Always but skuber cannot provide an interactive terminal"
+      )
+    }
+
+    val requestJson = ExecCredentialProtocol.buildRequestJson(exec.apiVersion, clusterInfo)
+    val extraEnv = exec.env.map(e => e.name -> e.value) :+ ("KUBERNETES_EXEC_INFO" -> requestJson)
+    val commandLine = exec.command +: exec.args
+
+    val stdout = new StringBuilder
+    val stderr = new StringBuilder
+    val logger = ProcessLogger(
+      line => { stdout.append(line).append('\n'); () },
+      line => { stderr.append(line).append('\n'); () }
+    )
+
+    val exitCode =
+      try {
+        // connectInput defaults to false here (no ProcessIO/#!< used), so the child's stdin is
+        // simply closed/empty rather than inherited - appropriate since skuber always declares
+        // itself non-interactive (spec.interactive=false) regardless of interactiveMode.
+        Process(commandLine, cwd = None, extraEnv: _*).run(logger).exitValue()
+      } catch {
+        case NonFatal(e) =>
+          val hint = exec.installHint.map(h => s" ($h)").getOrElse("")
+          throw new RuntimeException(s"failed to execute credential plugin '${exec.command}'$hint: ${e.getMessage}", e)
+      }
+
+    if (exitCode != 0) {
+      sys.error(s"credential plugin '${exec.command}' exited with code $exitCode: ${stderr.toString.trim}")
+    }
+
+    ExecCredentialProtocol.parseResponse(stdout.toString)
+  }
+}

--- a/core/src/main/scala/skuber/api/kubeconfig/KubeconfigConverter.scala
+++ b/core/src/main/scala/skuber/api/kubeconfig/KubeconfigConverter.scala
@@ -1,0 +1,184 @@
+package skuber.api.kubeconfig
+
+import java.io.InputStream
+import java.nio.file.{Files, Path, Paths}
+import java.time.{Duration => JDuration, Instant}
+import java.util.Base64
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+import skuber.api.Configuration
+import skuber.api.client._
+import skuber.model.Namespace
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+/**
+ * Converts the raw, spec-faithful [[RawConfig]] model (see [[KubeconfigModel]]) into skuber's runtime
+ * `skuber.api.Configuration`/`skuber.api.client.{Cluster, Context, AuthInfo}` types.
+ *
+ * This is the sole entry point used by `skuber.api.Configuration.parseKubeconfigStream`.
+ */
+private[skuber] object KubeconfigConverter {
+
+  // Bearer-token expiry skew, mirrors the existing GcpRefresh.expired buffer in
+  // skuber.api.client.package.
+  private val ExpirySkewSeconds = 20L
+
+  // Used when an exec plugin's response doesn't include an expirationTimestamp - without one we
+  // have no proactive-refresh signal at all, so fall back to a conservative revalidation interval
+  // rather than caching the credential forever.
+  private val DefaultCredentialValidity: FiniteDuration = 60.seconds
+
+  // token/exec-plugin credential refreshes are blocking (subprocess exec, file reads) - give them
+  // a small dedicated, idle-when-unused thread pool rather than risk blocking a caller's I/O
+  // dispatcher thread. core has no Akka/Pekko dispatcher of its own to borrow.
+  private val blockingThreadCount = new AtomicInteger(0)
+  private val blockingExecutor = Executors.newCachedThreadPool { (r: Runnable) =>
+    val t = new Thread(r, s"skuber-kubeconfig-credential-refresh-${blockingThreadCount.incrementAndGet()}")
+    t.setDaemon(true)
+    t
+  }
+  private implicit val blockingExecutionContext: ExecutionContext = ExecutionContext.fromExecutorService(blockingExecutor)
+
+  def parse(is: InputStream, kubeconfigDir: Option[Path]): Try[Configuration] =
+    KubeconfigLoader.load(is).map(raw => toConfiguration(raw, kubeconfigDir))
+
+  private def toConfiguration(raw: RawConfig, kubeconfigDir: Option[Path]): Configuration = {
+    val clusterMap: Map[String, Cluster] =
+      raw.clusters.map(nc => nc.name -> toCluster(nc.cluster, kubeconfigDir)).toMap
+
+    val rawClusterByName: Map[String, RawCluster] = raw.clusters.map(nc => nc.name -> nc.cluster).toMap
+    val rawUserByName: Map[String, RawAuthInfo] = raw.users.map(nu => nu.name -> nu.user).toMap
+
+    // The flat, top-level `users:` map has no associated cluster, so an exec plugin configured
+    // with provideClusterInfo=true simply won't receive cluster info when its AuthInfo is looked
+    // up this way. In practice only skuber.api.Configuration.contexts (and thus currentContext) is
+    // ever used to actually drive HTTP requests - see toAuthInfo's cluster-bound rebuild below.
+    val userMap: Map[String, AuthInfo] =
+      raw.users.map(nu => nu.name -> toAuthInfo(nu.user, clusterForExec = None, kubeconfigDir)).toMap
+
+    val contextMap: Map[String, Context] = raw.contexts.map { namedContext =>
+      val rawContext = namedContext.context
+      val clusterName = rawContext.cluster.filterNot(_.isEmpty)
+      val userName = rawContext.user.filterNot(_.isEmpty)
+
+      val boundCluster = clusterName.flatMap(clusterMap.get)
+      val cluster = boundCluster.getOrElse(Cluster())
+
+      val authInfo = userName.flatMap(rawUserByName.get) match {
+        case Some(rawUser) => toAuthInfo(rawUser, clusterForExec = boundCluster, kubeconfigDir)
+        case None => NoAuth
+      }
+
+      val namespace = rawContext.namespace.fold(Namespace.default)(Namespace.forName)
+
+      namedContext.name -> Context(cluster, authInfo, namespace)
+    }.toMap
+
+    val currentContext = raw.currentContext.flatMap(contextMap.get).getOrElse(Context())
+
+    Configuration(clusterMap, contextMap, currentContext, userMap)
+  }
+
+  private def toCluster(raw: RawCluster, kubeconfigDir: Option[Path]): Cluster =
+    Cluster(
+      apiVersion = raw.apiVersion.getOrElse("v1"),
+      // Preserves a pre-existing quirk: the legacy parser's own fallback here ("...:8001") differs
+      // from Cluster()'s own default server ("...:8080", skuber.api.client.defaultApiServerURL).
+      server = raw.server.getOrElse("http://localhost:8001"),
+      insecureSkipTLSVerify = raw.insecureSkipTLSVerify.getOrElse(false),
+      certificateAuthority = pathOrData(raw.certificateAuthority, raw.certificateAuthorityData, kubeconfigDir)
+    )
+
+  private def toAuthInfo(raw: RawAuthInfo, clusterForExec: Option[Cluster], kubeconfigDir: Option[Path]): AuthInfo = {
+    raw.exec match {
+      case Some(exec) => execAuthInfo(exec, clusterForExec)
+      case None =>
+        raw.authProvider match {
+          case Some(provider) => authProviderAuthInfo(provider)
+          case None =>
+            val clientCertificate = pathOrData(raw.clientCertificate, raw.clientCertificateData, kubeconfigDir)
+            val clientKey = pathOrData(raw.clientKey, raw.clientKeyData, kubeconfigDir)
+            (raw.username, raw.password, raw.token, raw.tokenFile, clientCertificate, clientKey) match {
+              case (Some(u), Some(p), _, _, _, _) => BasicAuth(u, p)
+              case (_, _, Some(t), _, _, _) => TokenAuth(t)
+              case (_, _, None, Some(file), _, _) => tokenFileAuthInfo(file)
+              case (u, _, _, _, Some(cert), Some(key)) => CertAuth(cert, key, u)
+              case _ => NoAuth
+            }
+        }
+    }
+  }
+
+  private def authProviderAuthInfo(provider: RawAuthProvider): AuthInfo = provider.name.toLowerCase match {
+    case "oidc" =>
+      OidcAuth(idToken = provider.idToken.getOrElse(sys.error("auth-provider 'oidc' config missing 'id-token'")))
+    case "gcp" =>
+      GcpAuth(
+        accessToken = provider.accessToken,
+        expiry = provider.expiry,
+        cmdPath = provider.cmdPath.getOrElse(sys.error("auth-provider 'gcp' config missing 'cmd-path'")),
+        cmdArgs = provider.cmdArgs.getOrElse(sys.error("auth-provider 'gcp' config missing 'cmd-args'"))
+      )
+    case _ => NoAuth
+  }
+
+  // Re-reads the token file on each reload, matching client-go's periodically-re-read-token-file
+  // semantics, capped by DefaultCredentialValidity so we don't re-read on every single request.
+  private def tokenFileAuthInfo(path: String): AuthInfo = {
+    def reload(): Future[(FiniteDuration, String)] = Future {
+      val token = new String(Files.readAllBytes(Paths.get(path)), "UTF-8").trim
+      (DefaultCredentialValidity, token)
+    }
+    reloadableAccessTokenAuth(() => reload())
+  }
+
+  private def execAuthInfo(exec: RawExecConfig, clusterForExec: Option[Cluster]): AuthInfo = {
+    def reload(): Future[(FiniteDuration, String)] = Future {
+      val clusterInfo = if (exec.provideClusterInfo) clusterForExec.map(toExecClusterInfo) else None
+      ExecCredentialRunner.run(exec, clusterInfo).get match {
+        case ExecToken(token, expiresAt) =>
+          val validity = expiresAt
+            .map(expiry => JDuration.between(Instant.now, expiry.minusSeconds(ExpirySkewSeconds)))
+            .map(d => (d.toMillis max 0L).millis)
+            .getOrElse(DefaultCredentialValidity)
+          (validity, token)
+        case _: ExecClientCert =>
+          throw new UnsupportedOperationException(
+            s"credential plugin '${exec.command}' returned a client certificate, which skuber cannot yet use: " +
+              "TLS client certificates are only established once, when the HTTP connection pool is built, and " +
+              "cannot currently be refreshed from an exec plugin. This is a known limitation (tracked as " +
+              "follow-up work), affecting e.g. Teleport's 'tsh kube credentials' plugin."
+          )
+      }
+    }
+    reloadableAccessTokenAuth(() => reload())
+  }
+
+  private def toExecClusterInfo(cluster: Cluster): ExecClusterInfo = {
+    val certificateAuthorityDataBase64 = cluster.certificateAuthority.map {
+      case Right(bytes) => Base64.getEncoder.encodeToString(bytes)
+      case Left(path) => Base64.getEncoder.encodeToString(Files.readAllBytes(Paths.get(path)))
+    }
+    ExecClusterInfo(cluster.server, certificateAuthorityDataBase64, cluster.insecureSkipTLSVerify)
+  }
+
+  // Preserves the pre-existing precedence and relative-path-expansion behavior: an embedded *-data
+  // value overrides a path, and a relative path is resolved against kubeconfigDir (the parsed
+  // file's parent directory) when one was supplied.
+  private def pathOrData(pathOpt: Option[String], dataOpt: Option[String], kubeconfigDir: Option[Path]): Option[PathOrData] =
+    (pathOpt, dataOpt) match {
+      case (_, Some(base64Data)) => Some(Right(Base64.getDecoder.decode(base64Data)))
+      case (Some(p), _) =>
+        val expandedPath = (Paths.get(p), kubeconfigDir) match {
+          case (basePath, Some(dir)) if !basePath.isAbsolute =>
+            Paths.get(dir.normalize.toString, basePath.normalize.toString).normalize.toString
+          case _ => p
+        }
+        Some(Left(expandedPath))
+      case (None, None) => None
+    }
+}

--- a/core/src/main/scala/skuber/api/kubeconfig/KubeconfigLoader.scala
+++ b/core/src/main/scala/skuber/api/kubeconfig/KubeconfigLoader.scala
@@ -1,0 +1,39 @@
+package skuber.api.kubeconfig
+
+import java.io.InputStream
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.yaml.snakeyaml.Yaml
+import play.api.libs.json._
+
+import scala.util.Try
+
+/**
+ * Loads a kubeconfig YAML document into the [[RawConfig]] model.
+ *
+ * Parsing pipeline: SnakeYAML (already a skuber dependency) decodes the YAML into a plain
+ * `java.util.Map`/`List`/`String`/`Number`/`Boolean`/`Date` object graph, Jackson's `ObjectMapper`
+ * serializes that graph to a JSON string (it natively understands all of those Java types - no
+ * custom (de)serializers are needed), and Play JSON parses that string and decodes it via the
+ * typed `Reads` in [[KubeconfigModel]].
+ *
+ * `java.util.Date` (which SnakeYAML produces for unquoted YAML timestamps, e.g. a legacy
+ * `auth-provider: gcp` config's unquoted `expiry:` field) is deliberately left to Jackson's default
+ * serialization as a JSON number (epoch millis) rather than attempting to match Jackson's own
+ * default ISO-ish date-string format against a `DateTimeFormatter` later - epoch millis is
+ * unambiguous. See `KubeconfigInstant.parseLenient`, which handles both that and quoted ISO-8601
+ * date strings (which SnakeYAML leaves as plain `String`s).
+ */
+private[kubeconfig] object KubeconfigLoader {
+
+  private val mapper = new ObjectMapper()
+
+  def load(is: InputStream): Try[RawConfig] = Try {
+    val yamlObject = new Yaml().load[Object](is)
+    val jsonString = mapper.writeValueAsString(yamlObject)
+    Json.parse(jsonString).validate[RawConfig] match {
+      case JsSuccess(config, _) => config
+      case error: JsError => throw new RuntimeException(s"failed to parse kubeconfig: ${JsError.toJson(error)}")
+    }
+  }
+}

--- a/core/src/main/scala/skuber/api/kubeconfig/KubeconfigModel.scala
+++ b/core/src/main/scala/skuber/api/kubeconfig/KubeconfigModel.scala
@@ -1,0 +1,218 @@
+package skuber.api.kubeconfig
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+import scala.util.{Success, Try}
+
+/**
+ * Explicit modelling of the kubeconfig.v1 schema (https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/)
+ * as parsed from the JSON produced by [[KubeconfigLoader]] (itself converted from YAML via SnakeYAML + Jackson).
+ *
+ * These are intentionally *raw*, one-to-one representations of the on-disk schema - conversion to skuber's
+ * runtime `skuber.api.client.Cluster`/`Context`/`AuthInfo`/`skuber.api.Configuration` types (which must remain
+ * binary compatible, so cannot simply grow new fields) happens separately in [[KubeconfigConverter]].
+ *
+ * Deliberately not modelled: `preferences`, impersonation (`as`/`as-uid`/`as-groups`/`as-user-extra`),
+ * cluster-level `tls-server-name`/`proxy-url`/`disable-compression`. None of these appear in real-world
+ * kubeconfig files skuber needs to support today, and the latter three would require new fields on the
+ * runtime `Cluster`/`Context` case classes to have any effect - a binary-incompatible change deferred to a
+ * future major version.
+ */
+private[kubeconfig] object KubeconfigInstant {
+  private val formatters = List(DateTimeFormatter.ISO_INSTANT, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+  /**
+   * Best-effort instant parsing that never fails - an unrecognized shape simply yields `None`. This mirrors
+   * the pre-rewrite behavior of the legacy `auth-provider: gcp` config's `expiry` field, where an unparseable
+   * date was historically treated as "no expiry" rather than a hard parse failure, and is reused for the
+   * exec-credential response's `status.expirationTimestamp` for the same reason: a plugin returning a
+   * malformed timestamp shouldn't make the whole credential fetch fail, just fall back to a conservative
+   * refresh interval.
+   */
+  def parseLenient(value: JsValue): Option[Instant] = value match {
+    case JsNumber(millis) => Some(Instant.ofEpochMilli(millis.toLong))
+    case JsString(s) => formatters.iterator.map(fmt => Try(Instant.from(fmt.parse(s)))).collectFirst { case Success(i) => i }
+    case _ => None
+  }
+
+  def readsLenientOptional(path: JsPath): Reads[Option[Instant]] =
+    path.readNullable[JsValue].map(_.flatMap(parseLenient))
+}
+
+private[kubeconfig] final case class RawNamedExtension(name: String, extension: JsValue)
+
+private[kubeconfig] object RawNamedExtension {
+  implicit val reads: Reads[RawNamedExtension] = (
+    (JsPath \ "name").read[String] and
+      (JsPath \ "extension").read[JsValue]
+    )(RawNamedExtension.apply _)
+
+  val readsList: Reads[List[RawNamedExtension]] =
+    (JsPath \ "extensions").readNullable[List[RawNamedExtension]].map(_.getOrElse(Nil))
+}
+
+private[kubeconfig] final case class RawExecEnvVar(name: String, value: String)
+
+private[kubeconfig] object RawExecEnvVar {
+  implicit val reads: Reads[RawExecEnvVar] = (
+    (JsPath \ "name").read[String] and
+      (JsPath \ "value").read[String]
+    )(RawExecEnvVar.apply _)
+}
+
+private[kubeconfig] final case class RawExecConfig(
+  command: String,
+  args: List[String],
+  env: List[RawExecEnvVar],
+  apiVersion: String,
+  installHint: Option[String],
+  provideClusterInfo: Boolean,
+  interactiveMode: String
+)
+
+private[kubeconfig] object RawExecConfig {
+  implicit val reads: Reads[RawExecConfig] = (
+    (JsPath \ "command").read[String] and
+      (JsPath \ "args").readNullable[List[String]].map(_.getOrElse(Nil)) and
+      (JsPath \ "env").readNullable[List[RawExecEnvVar]].map(_.getOrElse(Nil)) and
+      (JsPath \ "apiVersion").read[String] and
+      (JsPath \ "installHint").readNullable[String] and
+      (JsPath \ "provideClusterInfo").readNullable[Boolean].map(_.getOrElse(false)) and
+      (JsPath \ "interactiveMode").readNullable[String].map(_.getOrElse("IfAvailable"))
+    )(RawExecConfig.apply _)
+}
+
+private[kubeconfig] final case class RawAuthProvider(
+  name: String,
+  idToken: Option[String],
+  accessToken: Option[String],
+  expiry: Option[Instant],
+  cmdPath: Option[String],
+  cmdArgs: Option[String]
+)
+
+private[kubeconfig] object RawAuthProvider {
+  implicit val reads: Reads[RawAuthProvider] = (
+    (JsPath \ "name").read[String] and
+      (JsPath \ "config" \ "id-token").readNullable[String] and
+      (JsPath \ "config" \ "access-token").readNullable[String] and
+      KubeconfigInstant.readsLenientOptional(JsPath \ "config" \ "expiry") and
+      (JsPath \ "config" \ "cmd-path").readNullable[String] and
+      (JsPath \ "config" \ "cmd-args").readNullable[String]
+    )(RawAuthProvider.apply _)
+}
+
+private[kubeconfig] final case class RawAuthInfo(
+  clientCertificate: Option[String],
+  clientCertificateData: Option[String],
+  clientKey: Option[String],
+  clientKeyData: Option[String],
+  token: Option[String],
+  tokenFile: Option[String],
+  username: Option[String],
+  password: Option[String],
+  authProvider: Option[RawAuthProvider],
+  exec: Option[RawExecConfig],
+  extensions: List[RawNamedExtension]
+)
+
+private[kubeconfig] object RawAuthInfo {
+  implicit val reads: Reads[RawAuthInfo] = (
+    (JsPath \ "client-certificate").readNullable[String] and
+      (JsPath \ "client-certificate-data").readNullable[String] and
+      (JsPath \ "client-key").readNullable[String] and
+      (JsPath \ "client-key-data").readNullable[String] and
+      (JsPath \ "token").readNullable[String] and
+      (JsPath \ "tokenFile").readNullable[String] and
+      (JsPath \ "username").readNullable[String] and
+      (JsPath \ "password").readNullable[String] and
+      (JsPath \ "auth-provider").readNullable[RawAuthProvider] and
+      (JsPath \ "exec").readNullable[RawExecConfig] and
+      RawNamedExtension.readsList
+    )(RawAuthInfo.apply _)
+}
+
+private[kubeconfig] final case class RawNamedUser(name: String, user: RawAuthInfo)
+
+private[kubeconfig] object RawNamedUser {
+  implicit val reads: Reads[RawNamedUser] = (
+    (JsPath \ "name").read[String] and
+      (JsPath \ "user").read[RawAuthInfo]
+    )(RawNamedUser.apply _)
+}
+
+private[kubeconfig] final case class RawCluster(
+  apiVersion: Option[String],
+  server: Option[String],
+  insecureSkipTLSVerify: Option[Boolean],
+  certificateAuthority: Option[String],
+  certificateAuthorityData: Option[String],
+  extensions: List[RawNamedExtension]
+)
+
+private[kubeconfig] object RawCluster {
+  implicit val reads: Reads[RawCluster] = (
+    (JsPath \ "api-version").readNullable[String] and
+      (JsPath \ "server").readNullable[String] and
+      (JsPath \ "insecure-skip-tls-verify").readNullable[Boolean] and
+      (JsPath \ "certificate-authority").readNullable[String] and
+      (JsPath \ "certificate-authority-data").readNullable[String] and
+      RawNamedExtension.readsList
+    )(RawCluster.apply _)
+}
+
+private[kubeconfig] final case class RawNamedCluster(name: String, cluster: RawCluster)
+
+private[kubeconfig] object RawNamedCluster {
+  implicit val reads: Reads[RawNamedCluster] = (
+    (JsPath \ "name").read[String] and
+      (JsPath \ "cluster").read[RawCluster]
+    )(RawNamedCluster.apply _)
+}
+
+private[kubeconfig] final case class RawContext(
+  cluster: Option[String],
+  user: Option[String],
+  namespace: Option[String],
+  extensions: List[RawNamedExtension]
+)
+
+private[kubeconfig] object RawContext {
+  implicit val reads: Reads[RawContext] = (
+    (JsPath \ "cluster").readNullable[String] and
+      (JsPath \ "user").readNullable[String] and
+      (JsPath \ "namespace").readNullable[String] and
+      RawNamedExtension.readsList
+    )(RawContext.apply _)
+}
+
+private[kubeconfig] final case class RawNamedContext(name: String, context: RawContext)
+
+private[kubeconfig] object RawNamedContext {
+  implicit val reads: Reads[RawNamedContext] = (
+    (JsPath \ "name").read[String] and
+      (JsPath \ "context").read[RawContext]
+    )(RawNamedContext.apply _)
+}
+
+private[kubeconfig] final case class RawConfig(
+  clusters: List[RawNamedCluster],
+  users: List[RawNamedUser],
+  contexts: List[RawNamedContext],
+  currentContext: Option[String],
+  extensions: List[RawNamedExtension]
+)
+
+private[kubeconfig] object RawConfig {
+  implicit val reads: Reads[RawConfig] = (
+    (JsPath \ "clusters").readNullable[List[RawNamedCluster]].map(_.getOrElse(Nil)) and
+      (JsPath \ "users").readNullable[List[RawNamedUser]].map(_.getOrElse(Nil)) and
+      (JsPath \ "contexts").readNullable[List[RawNamedContext]].map(_.getOrElse(Nil)) and
+      (JsPath \ "current-context").readNullable[String] and
+      RawNamedExtension.readsList
+    )(RawConfig.apply _)
+}

--- a/core/src/test/scala/skuber/api/ConfigurationSpec.scala
+++ b/core/src/test/scala/skuber/api/ConfigurationSpec.scala
@@ -237,6 +237,105 @@ users:
     clientCertificate must beLeft("/top/level/path/path/to/my/client/cert")
   }
 
+  "parse exec-based auth (AWS EKS/GKE/Teleport shapes) and tokenFile auth, without executing anything" >> {
+    val execConfigStr = """
+apiVersion: v1
+kind: Config
+current-context: aws-context
+clusters:
+- cluster:
+    server: https://eks.example.com
+    certificate-authority-data: bXktY2VydA==
+  name: aws-cluster
+- cluster:
+    server: https://34.1.2.3
+  name: gke-cluster
+- cluster:
+    server: https://teleport.example.com:3026
+    extensions:
+    - extension: teleport.example.com
+      name: kubeconfig.teleport.dev/teleport-cluster-name
+  name: teleport-cluster
+contexts:
+- context:
+    cluster: aws-cluster
+    user: aws-user
+  name: aws-context
+- context:
+    cluster: gke-cluster
+    user: gke-user
+  name: gke-context
+- context:
+    cluster: teleport-cluster
+    user: teleport-user
+    extensions:
+    - extension: teleport.example.com
+      name: teleport.kube.name
+  name: teleport-context
+- context:
+    cluster: aws-cluster
+    user: tokenfile-user
+  name: tokenfile-context
+users:
+- name: aws-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+      args:
+      - eks
+      - get-token
+      - --cluster-name
+      - my-cluster
+      env:
+      - name: AWS_PROFILE
+        value: my-profile
+      interactiveMode: IfAvailable
+      provideClusterInfo: false
+- name: gke-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+      args: null
+      env: null
+      installHint: install gke-gcloud-auth-plugin
+      interactiveMode: IfAvailable
+      provideClusterInfo: true
+- name: teleport-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: /usr/local/bin/tsh
+      args:
+      - kube
+      - credentials
+      - --kube-cluster=my-cluster
+      - --teleport-cluster=teleport.example.com
+      - --proxy=teleport.example.com:443
+      env: null
+      provideClusterInfo: false
+    extensions:
+    - extension: teleport.example.com
+      name: kubeconfig.teleport.dev/profile-name
+- name: tokenfile-user
+  user:
+    tokenFile: /path/to/token/file
+"""
+    val is = new ByteArrayInputStream(execConfigStr.getBytes(java.nio.charset.Charset.forName("UTF-8")))
+    val parsed = K8SConfiguration.parseKubeconfigStream(is).get
+
+    parsed.contexts("aws-context").authInfo must beAnInstanceOf[AsyncAccessTokenAuth]
+    parsed.contexts("gke-context").authInfo must beAnInstanceOf[AsyncAccessTokenAuth]
+    parsed.contexts("teleport-context").authInfo must beAnInstanceOf[AsyncAccessTokenAuth]
+    parsed.contexts("tokenfile-context").authInfo must beAnInstanceOf[AsyncAccessTokenAuth]
+
+    parsed.users("aws-user") must beAnInstanceOf[AsyncAccessTokenAuth]
+    parsed.users("gke-user") must beAnInstanceOf[AsyncAccessTokenAuth]
+    parsed.users("teleport-user") must beAnInstanceOf[AsyncAccessTokenAuth]
+    parsed.users("tokenfile-user") must beAnInstanceOf[AsyncAccessTokenAuth]
+  }
+
   "ignore missing cluster and user references" >> {
     val config = """
 apiVersion: v1

--- a/core/src/test/scala/skuber/api/kubeconfig/ExecAuthSpec.scala
+++ b/core/src/test/scala/skuber/api/kubeconfig/ExecAuthSpec.scala
@@ -1,0 +1,124 @@
+package skuber.api.kubeconfig
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Path}
+import java.util.Base64
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+import skuber.api.Configuration
+import skuber.api.client.AsyncAccessTokenAuth
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class ExecAuthSpec extends Specification {
+
+  sequential
+
+  private def writeExecutableScript(content: String): Path = {
+    val script = Files.createTempFile("exec-auth-plugin", ".sh")
+    Files.write(script, (s"#!/bin/sh\n$content\n").getBytes(UTF_8))
+    script.toFile.setExecutable(true)
+    script
+  }
+
+  private def kubeconfig(execCommand: Path, provideClusterInfo: Boolean = false): String =
+    s"""
+apiVersion: v1
+kind: Config
+current-context: test-context
+clusters:
+- cluster:
+    server: https://my-cluster.example:6443
+    certificate-authority-data: ${Base64.getEncoder.encodeToString("ca-bytes".getBytes(UTF_8))}
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+users:
+- name: test-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: $execCommand
+      provideClusterInfo: $provideClusterInfo
+"""
+
+  private def parse(execCommand: Path, provideClusterInfo: Boolean = false): Configuration =
+    Configuration.parseKubeconfigStream(new ByteArrayInputStream(kubeconfig(execCommand, provideClusterInfo).getBytes(UTF_8))).get
+
+  private def accessToken(auth: skuber.api.client.AuthInfo): String =
+    Await.result(auth.asInstanceOf[AsyncAccessTokenAuth].accessToken(), 5.seconds)
+
+  "exec-based auth" should {
+
+    "not execute the plugin at parse time (lazy)" >> {
+      val counter = Files.createTempFile("exec-auth-counter", ".txt")
+      Files.delete(counter)
+      val script = writeExecutableScript(s"""echo x >> $counter
+echo '{"status":{"token":"tok","expirationTimestamp":"2099-01-01T00:00:00Z"}}'""")
+
+      val config = parse(script)
+      Files.exists(counter) must beFalse
+
+      accessToken(config.currentContext.authInfo) must beEqualTo("tok")
+      Files.readAllLines(counter).size must beEqualTo(1)
+    }
+
+    "cache the token and not re-invoke the plugin before it expires" >> {
+      val counter = Files.createTempFile("exec-auth-counter", ".txt")
+      Files.delete(counter)
+      val script = writeExecutableScript(s"""echo x >> $counter
+echo '{"status":{"token":"tok","expirationTimestamp":"2099-01-01T00:00:00Z"}}'""")
+
+      val config = parse(script)
+      accessToken(config.currentContext.authInfo) must beEqualTo("tok")
+      accessToken(config.currentContext.authInfo) must beEqualTo("tok")
+      Files.readAllLines(counter).size must beEqualTo(1)
+    }
+
+    "re-invoke the plugin once its returned credential has expired" >> {
+      val counter = Files.createTempFile("exec-auth-counter", ".txt")
+      Files.delete(counter)
+      val script = writeExecutableScript(s"""echo x >> $counter
+echo '{"status":{"token":"tok","expirationTimestamp":"2000-01-01T00:00:00Z"}}'""")
+
+      val config = parse(script)
+      accessToken(config.currentContext.authInfo) must beEqualTo("tok")
+      accessToken(config.currentContext.authInfo) must beEqualTo("tok")
+      Files.readAllLines(counter).size must beEqualTo(2)
+    }
+
+    "fail clearly (not silently) when the plugin returns a client certificate instead of a token" >> {
+      val certB64 = Base64.getEncoder.encodeToString("fake-cert-pem".getBytes(UTF_8))
+      val keyB64 = Base64.getEncoder.encodeToString("fake-key-pem".getBytes(UTF_8))
+      val script = writeExecutableScript(s"""echo '{"status":{"clientCertificateData":"$certB64","clientKeyData":"$keyB64"}}'""")
+
+      val config = parse(script)
+      accessToken(config.currentContext.authInfo) must throwA[UnsupportedOperationException]
+    }
+
+    "include the bound cluster's connection info when provideClusterInfo=true, only for the context-bound auth" >> {
+      val captureFile = Files.createTempFile("exec-auth-capture", ".json")
+      val script = writeExecutableScript(s"""printf '%s' "$$KUBERNETES_EXEC_INFO" > $captureFile
+echo '{"status":{"token":"tok","expirationTimestamp":"2099-01-01T00:00:00Z"}}'""")
+
+      val config = parse(script, provideClusterInfo = true)
+
+      accessToken(config.currentContext.authInfo) must beEqualTo("tok")
+      val contextRequest = Json.parse(Files.readAllBytes(captureFile))
+      (contextRequest \ "spec" \ "cluster" \ "server").as[String] must beEqualTo("https://my-cluster.example:6443")
+
+      // The flat top-level `users` map entry for the same user has no associated cluster (it isn't
+      // bound to one until a context pairs it with a cluster), so its own, independent lazy AuthInfo
+      // omits spec.cluster entirely when invoked directly.
+      accessToken(config.users("test-user")) must beEqualTo("tok")
+      val flatUserRequest = Json.parse(Files.readAllBytes(captureFile))
+      (flatUserRequest \ "spec" \ "cluster").toOption must beNone
+    }
+  }
+}

--- a/core/src/test/scala/skuber/api/kubeconfig/ExecCredentialRunnerSpec.scala
+++ b/core/src/test/scala/skuber/api/kubeconfig/ExecCredentialRunnerSpec.scala
@@ -1,0 +1,121 @@
+package skuber.api.kubeconfig
+
+import java.nio.file.{Files, Path}
+import java.time.Instant
+import java.util.Base64
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+class ExecCredentialRunnerSpec extends Specification {
+
+  private def exec(
+    command: String,
+    args: List[String] = Nil,
+    env: List[RawExecEnvVar] = Nil,
+    apiVersion: String = "client.authentication.k8s.io/v1beta1",
+    installHint: Option[String] = None,
+    provideClusterInfo: Boolean = false,
+    interactiveMode: String = "IfAvailable"
+  ): RawExecConfig = RawExecConfig(command, args, env, apiVersion, installHint, provideClusterInfo, interactiveMode)
+
+  private def shell(script: String): RawExecConfig = exec("/bin/sh", List("-c", script))
+
+  "ExecCredentialRunner.run" should {
+
+    "parse a successful token response with an expiry" >> {
+      val result = ExecCredentialRunner.run(
+        shell("""echo '{"status":{"token":"tok-123","expirationTimestamp":"2099-01-01T00:00:00Z"}}'"""),
+        None
+      )
+      result must beSuccessfulTry(ExecToken("tok-123", Some(Instant.parse("2099-01-01T00:00:00Z"))))
+    }
+
+    "parse a successful token response with no expiry" >> {
+      val result = ExecCredentialRunner.run(shell("""echo '{"status":{"token":"tok-123"}}'"""), None)
+      result must beSuccessfulTry(ExecToken("tok-123", None))
+    }
+
+    "parse a successful client-certificate response (Teleport's actual shape)" >> {
+      val certB64 = Base64.getEncoder.encodeToString("fake-cert-pem".getBytes("UTF-8"))
+      val keyB64 = Base64.getEncoder.encodeToString("fake-key-pem".getBytes("UTF-8"))
+      val result = ExecCredentialRunner.run(
+        shell(s"""echo '{"status":{"clientCertificateData":"$certB64","clientKeyData":"$keyB64"}}'"""),
+        None
+      )
+      result must beSuccessfulTry.like { case ExecClientCert(cert, key) =>
+        new String(cert, "UTF-8") must beEqualTo("fake-cert-pem")
+        new String(key, "UTF-8") must beEqualTo("fake-key-pem")
+      }
+    }
+
+    "fail with the exit code and stderr when the plugin exits non-zero" >> {
+      val result = ExecCredentialRunner.run(shell("echo 'boom' 1>&2; exit 3"), None)
+      result must beFailedTry.like { case e => e.getMessage must (contain("exited with code 3") and contain("boom")) }
+    }
+
+    "fail clearly when the plugin's output isn't valid JSON" >> {
+      val result = ExecCredentialRunner.run(shell("echo 'not json'"), None)
+      result must beFailedTry.like { case e => e.getMessage must contain("valid JSON") }
+    }
+
+    "fail clearly when the plugin's output has no 'status' field" >> {
+      val result = ExecCredentialRunner.run(shell("""echo '{"apiVersion":"v1","kind":"ExecCredential"}'"""), None)
+      result must beFailedTry.like { case e => e.getMessage must contain("no 'status' field") }
+    }
+
+    "fail clearly when the plugin's status has neither a token nor a cert" >> {
+      val result = ExecCredentialRunner.run(shell("""echo '{"status":{}}'"""), None)
+      result must beFailedTry.like { case e => e.getMessage must contain("neither a token nor a client certificate") }
+    }
+
+    "fail with the installHint when the command can't be found" >> {
+      val result = ExecCredentialRunner.run(
+        exec("this-command-does-not-exist-xyz", installHint = Some("brew install this-command")),
+        None
+      )
+      result must beFailedTry.like { case e => e.getMessage must contain("brew install this-command") }
+    }
+
+    "fail fast without spawning anything when interactiveMode is Always" >> {
+      val markerFile = Files.createTempFile("exec-marker", ".txt")
+      Files.delete(markerFile)
+      val result = ExecCredentialRunner.run(shell(s"touch $markerFile").copy(interactiveMode = "Always"), None)
+      result must beFailedTry.like { case e => e.getMessage must contain("interactiveMode=Always") }
+      Files.exists(markerFile) must beFalse
+    }
+
+    "pass apiVersion, spec.interactive=false and (when requested) cluster info via KUBERNETES_EXEC_INFO" >> {
+      val captureFile: Path = Files.createTempFile("exec-info-capture", ".json")
+
+      val withoutClusterInfo = ExecCredentialRunner.run(
+        shell(s"""printf '%s' "$$KUBERNETES_EXEC_INFO" > $captureFile; echo '{"status":{"token":"ok"}}'"""),
+        None
+      )
+      withoutClusterInfo must beSuccessfulTry
+      val requestWithoutCluster = Json.parse(Files.readAllBytes(captureFile))
+      (requestWithoutCluster \ "apiVersion").as[String] must beEqualTo("client.authentication.k8s.io/v1beta1")
+      (requestWithoutCluster \ "spec" \ "interactive").as[Boolean] must beFalse
+      (requestWithoutCluster \ "spec" \ "cluster").toOption must beNone
+
+      val clusterInfo = ExecClusterInfo("https://my-cluster.example:6443", Some(Base64.getEncoder.encodeToString("ca-bytes".getBytes)), insecureSkipTLSVerify = true)
+      val withClusterInfo = ExecCredentialRunner.run(
+        shell(s"""printf '%s' "$$KUBERNETES_EXEC_INFO" > $captureFile; echo '{"status":{"token":"ok"}}'"""),
+        Some(clusterInfo)
+      )
+      withClusterInfo must beSuccessfulTry
+      val requestWithCluster = Json.parse(Files.readAllBytes(captureFile))
+      (requestWithCluster \ "spec" \ "cluster" \ "server").as[String] must beEqualTo("https://my-cluster.example:6443")
+      (requestWithCluster \ "spec" \ "cluster" \ "insecure-skip-tls-verify").as[Boolean] must beTrue
+      (requestWithCluster \ "spec" \ "cluster" \ "certificate-authority-data").asOpt[String] must beSome
+    }
+
+    "pass the exec config's extra env vars through to the plugin" >> {
+      val result = ExecCredentialRunner.run(
+        exec("/bin/sh", List("-c", """echo "{\"status\":{\"token\":\"$MY_VAR\"}}""""), env = List(RawExecEnvVar("MY_VAR", "from-env"))),
+        None
+      )
+      result must beSuccessfulTry(ExecToken("from-env", None))
+    }
+  }
+}


### PR DESCRIPTION
This rewrites kubeconfig handling.

It models it properly according to the spec here:

https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/

To parse, it still uses SnakeYAML, but converts it to JSON, and then parses using play-json.

It also provides support for exec providers, which is basically how all cloud based providers configure kubectl these days.

One thing it doesn't do is provide support for client certificates returned by an exec plugin, that's going to require refactoring of all the client implementations, so I thought it best to keep that work separate.